### PR TITLE
feat: refactor generator to split properties variable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,12 @@ go.work.sum
 # .vscode/
 
 /tfmodmake
+
+# Terraform example artifacts
+**/.terraform/
+**/terraform.tfstate
+**/terraform.tfstate.*
+**/.terraform.lock.hcl
+**/crash.log
+**/crash.*.log
+**/examples/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ CLI tool to generate base Terraform configuration (`variables.tf` and `locals.tf
 *   Parses OpenAPI 3.0 specifications from local files or URLs.
 *   Extracts schema for a specific resource type.
 *   Generates Terraform variables with appropriate types and descriptions.
+*   Flattens the OpenAPI top-level `properties` bag into idiomatic top-level Terraform variables.
 *   Handles nested objects and arrays.
 *   Generates validation blocks for top-level enum variables.
 *   Creates a `locals.tf` file to map Terraform variables back to the API JSON structure.
@@ -58,9 +59,17 @@ This command reads the Terraform module at the specified path and generates:
 Generate configuration for the entire resource:
 
 ```bash
+# example with AKS and stable API
 ./tfmodmake \
-  -spec https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2023-01-01/managedClusters.json \
+  -spec https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-10-01/managedClusters.json \
   -resource Microsoft.ContainerService/managedClusters
+```
+
+```bash
+# example with Container Apps Managed Environment & preview API
+./tfmodmake \
+  -spec https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2025-10-02-preview/ManagedEnvironments.json \
+  -resource Microsoft.App/managedEnvironments
 ```
 
 ### Targeting a Sub-property
@@ -96,3 +105,7 @@ The tool generates four files in the current directory:
 2.  `locals.tf`: Contains the local value constructing the JSON body structure.
 3.  `main.tf`: Scaffold for the `azapi_resource` using the generated locals.
 4.  `outputs.tf`: Outputs exposing the resource ID and name.
+
+When generating the full resource schema (no `-root`), the OpenAPI top-level `properties` object is flattened so its children become top-level Terraform variables (for example `app_logs_configuration`, `custom_domain_configuration`, etc.), and `locals.tf` reconstructs the JSON `properties` object from those variables.
+
+When using `-root properties`, `locals.tf` represents the `properties` object and `main.tf` wraps it under `body.properties`.

--- a/pkg/terraform/generator.go
+++ b/pkg/terraform/generator.go
@@ -30,7 +30,7 @@ func Generate(schema *openapi3.Schema, resourceType string, localName string, ap
 			return err
 		}
 	}
-	if err := generateMain(resourceType, apiVersion, localName, supportsTags, supportsLocation, hasSchema); err != nil {
+	if err := generateMain(schema, resourceType, apiVersion, localName, supportsTags, supportsLocation, hasSchema); err != nil {
 		return err
 	}
 	if err := generateOutputs(); err != nil {
@@ -68,62 +68,11 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation b
 		return varBody, nil
 	}
 
-	if _, err := appendVariable("name", "The name of the resource.", hclwrite.TokensForIdentifier("string")); err != nil {
-		return err
-	}
-	body.AppendNewline()
-
-	if _, err := appendVariable("parent_id", "The parent resource ID for this resource.", hclwrite.TokensForIdentifier("string")); err != nil {
-		return err
-	}
-	body.AppendNewline()
-
-	if supportsLocation {
-		locationDescription := "The location of the resource."
-		locationType := hclwrite.TokensForIdentifier("string")
-
-		_, err := appendVariable("location", locationDescription, locationType)
-		if err != nil {
-			return err
-		}
-		body.AppendNewline()
-	}
-
-	if supportsTags {
-		tagsBody, err := appendVariable("tags", "Tags to apply to the resource.", hclwrite.TokensForFunctionCall("map", hclwrite.TokensForIdentifier("string")))
-		if err != nil {
-			return err
-		}
-		tagsBody.SetAttributeValue("default", cty.NullVal(cty.Map(cty.String)))
-		body.AppendNewline()
-	}
-
-	var keys []string
-	if schema != nil {
-		for k := range schema.Properties {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-	}
-
-	for i, name := range keys {
-		prop := schema.Properties[name]
-		if prop == nil || prop.Value == nil {
-			continue
-		}
-		if supportsTags && name == "tags" {
-			continue
-		}
-		if supportsLocation && name == "location" {
-			continue
-		}
-		propSchema := prop.Value
-
-		if propSchema.ReadOnly {
-			continue
+	appendSchemaVariable := func(tfName, originalName string, propSchema *openapi3.Schema, required []string) (*hclwrite.Body, error) {
+		if propSchema == nil {
+			return nil, nil
 		}
 
-		tfName := toSnakeCase(name)
 		tfType := mapType(propSchema)
 
 		var nestedDocSchema *openapi3.Schema
@@ -142,14 +91,18 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation b
 
 		varBody, err := appendVariable(tfName, "", tfType)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if isNestedObject {
 			var sb strings.Builder
 			desc := propSchema.Description
 			if desc == "" {
-				desc = fmt.Sprintf("The %s of the resource.", name)
+				if originalName != "" {
+					desc = fmt.Sprintf("The %s of the resource.", originalName)
+				} else {
+					desc = fmt.Sprintf("The %s of the resource.", tfName)
+				}
 			}
 			sb.WriteString(desc)
 			sb.WriteString("\n\n")
@@ -159,17 +112,20 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation b
 			}
 
 			sb.WriteString(buildNestedDescription(nestedDocSchema, ""))
-
 			hclgen.SetDescriptionAttribute(varBody, sb.String())
 		} else {
 			description := propSchema.Description
 			if description == "" {
-				description = fmt.Sprintf("The %s of the resource.", name)
+				if originalName != "" {
+					description = fmt.Sprintf("The %s of the resource.", originalName)
+				} else {
+					description = fmt.Sprintf("The %s of the resource.", tfName)
+				}
 			}
 			hclgen.SetDescriptionAttribute(varBody, description)
 		}
 
-		isRequired := slices.Contains(schema.Required, name)
+		isRequired := slices.Contains(required, originalName)
 		if !isRequired {
 			varBody.SetAttributeRaw("default", hclwrite.TokensForIdentifier("null"))
 		}
@@ -203,6 +159,124 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation b
 			validationBody.SetAttributeValue("error_message", cty.StringVal(fmt.Sprintf("%s must be one of: %s.", tfName, strings.Join(enumValuesRaw, ", "))))
 		}
 
+		return varBody, nil
+	}
+
+	if _, err := appendVariable("name", "The name of the resource.", hclwrite.TokensForIdentifier("string")); err != nil {
+		return err
+	}
+	body.AppendNewline()
+
+	if _, err := appendVariable("parent_id", "The parent resource ID for this resource.", hclwrite.TokensForIdentifier("string")); err != nil {
+		return err
+	}
+	body.AppendNewline()
+
+	if supportsLocation {
+		locationDescription := "The location of the resource."
+		locationType := hclwrite.TokensForIdentifier("string")
+
+		_, err := appendVariable("location", locationDescription, locationType)
+		if err != nil {
+			return err
+		}
+		body.AppendNewline()
+	}
+
+	if supportsTags {
+		tagsBody, err := appendVariable("tags", "Tags to apply to the resource.", hclwrite.TokensForFunctionCall("map", hclwrite.TokensForIdentifier("string")))
+		if err != nil {
+			return err
+		}
+		tagsBody.SetAttributeValue("default", cty.NullVal(cty.Map(cty.String)))
+		body.AppendNewline()
+	}
+
+	seenNames := map[string]struct{}{
+		"name":      {},
+		"parent_id": {},
+	}
+	if supportsLocation {
+		seenNames["location"] = struct{}{}
+	}
+	if supportsTags {
+		seenNames["tags"] = struct{}{}
+	}
+
+	var keys []string
+	if schema != nil {
+		for k := range schema.Properties {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+	}
+
+	for i, name := range keys {
+		prop := schema.Properties[name]
+		if prop == nil || prop.Value == nil {
+			continue
+		}
+		if supportsTags && name == "tags" {
+			continue
+		}
+		if supportsLocation && name == "location" {
+			continue
+		}
+		propSchema := prop.Value
+
+		if propSchema.ReadOnly {
+			continue
+		}
+
+		// Flatten the top-level "properties" bag into individual variables.
+		if name == "properties" {
+			if propSchema.Type != nil && slices.Contains(*propSchema.Type, "object") && len(propSchema.Properties) > 0 {
+				var childKeys []string
+				for ck := range propSchema.Properties {
+					childKeys = append(childKeys, ck)
+				}
+				sort.Strings(childKeys)
+
+				for _, ck := range childKeys {
+					childRef := propSchema.Properties[ck]
+					if childRef == nil || childRef.Value == nil {
+						continue
+					}
+					childSchema := childRef.Value
+					if childSchema.ReadOnly {
+						continue
+					}
+					tfName := toSnakeCase(ck)
+					if tfName == "" {
+						return fmt.Errorf("could not derive terraform variable name for properties.%s", ck)
+					}
+					if _, exists := seenNames[tfName]; exists {
+						return fmt.Errorf("terraform variable name collision: %q (from properties.%s)", tfName, ck)
+					}
+					seenNames[tfName] = struct{}{}
+
+					if _, err := appendSchemaVariable(tfName, ck, childSchema, propSchema.Required); err != nil {
+						return err
+					}
+					body.AppendNewline()
+				}
+				continue
+			}
+			// If "properties" isn't a concrete object, fall back to the old behavior.
+		}
+
+		tfName := toSnakeCase(name)
+		if tfName == "" {
+			return fmt.Errorf("could not derive terraform variable name for %s", name)
+		}
+		if _, exists := seenNames[tfName]; exists {
+			return fmt.Errorf("terraform variable name collision: %q (from %s)", tfName, name)
+		}
+		seenNames[tfName] = struct{}{}
+		if _, err := appendSchemaVariable(tfName, name, propSchema, schema.Required); err != nil {
+			return err
+		}
+
 		if i < len(keys)-1 {
 			body.AppendNewline()
 		}
@@ -226,6 +300,104 @@ func generateLocals(schema *openapi3.Schema, localName string) error {
 	localBody.SetAttributeRaw(localName, valueExpression)
 
 	return hclgen.WriteFile("locals.tf", file)
+}
+
+func isHCLIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if i == 0 {
+			if r != '_' && !unicode.IsLetter(r) {
+				return false
+			}
+			continue
+		}
+		if r != '_' && r != '-' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func tokensForObjectKey(key string) hclwrite.Tokens {
+	if isHCLIdentifier(key) {
+		return hclwrite.TokensForIdentifier(key)
+	}
+	return hclwrite.TokensForValue(cty.StringVal(key))
+}
+
+func constructFlattenedRootPropertiesValue(schema *openapi3.Schema, accessPath hclwrite.Tokens) hclwrite.Tokens {
+	// schema represents the OpenAPI schema at root.properties.
+	// The Terraform variables are flattened to var.<child> rather than var.properties.<child>.
+
+	if schema == nil {
+		return hclwrite.TokensForIdentifier("null")
+	}
+
+	var attrs []hclwrite.ObjectAttrTokens
+	var keys []string
+	for k := range schema.Properties {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var allNullConditions []hclwrite.Tokens
+	for _, k := range keys {
+		prop := schema.Properties[k]
+		if prop == nil || prop.Value == nil {
+			continue
+		}
+		if prop.Value.ReadOnly {
+			continue
+		}
+
+		snakeName := toSnakeCase(k)
+		var childAccess hclwrite.Tokens
+		childAccess = append(childAccess, accessPath...)
+		childAccess = append(childAccess, &hclwrite.Token{Type: hclsyntax.TokenDot, Bytes: []byte(".")})
+		childAccess = append(childAccess, hclwrite.TokensForIdentifier(snakeName)...)
+
+		// Used to null-out the whole properties object when nothing is set.
+		// We only do this when the properties schema doesn't declare required children.
+		condition := append(hclwrite.Tokens(nil), childAccess...)
+		condition = append(condition, &hclwrite.Token{Type: hclsyntax.TokenEqualOp, Bytes: []byte(" == ")})
+		condition = append(condition, hclwrite.TokensForIdentifier("null")...)
+		allNullConditions = append(allNullConditions, condition)
+
+		childValue := constructValue(prop.Value, childAccess, false)
+		attrs = append(attrs, hclwrite.ObjectAttrTokens{
+			Name:  tokensForObjectKey(k),
+			Value: childValue,
+		})
+	}
+
+	objTokens := hclwrite.TokensForObject(attrs)
+
+	if len(schema.Required) > 0 {
+		return objTokens
+	}
+
+	if len(allNullConditions) == 0 {
+		return hclwrite.TokensForIdentifier("null")
+	}
+
+	// Build: (var.a == null && var.b == null && ...) ? null : { ... }
+	var condition hclwrite.Tokens
+	for i, c := range allNullConditions {
+		if i > 0 {
+			condition = append(condition, &hclwrite.Token{Type: hclsyntax.TokenAnd, Bytes: []byte(" && ")})
+		}
+		condition = append(condition, c...)
+	}
+
+	var tokens hclwrite.Tokens
+	tokens = append(tokens, condition...)
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenQuestion, Bytes: []byte(" ? ")})
+	tokens = append(tokens, hclwrite.TokensForIdentifier("null")...)
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenColon, Bytes: []byte(" : ")})
+	tokens = append(tokens, objTokens...)
+	return tokens
 }
 
 func constructValue(schema *openapi3.Schema, accessPath hclwrite.Tokens, isRoot bool) hclwrite.Tokens {
@@ -279,6 +451,16 @@ func constructValue(schema *openapi3.Schema, accessPath hclwrite.Tokens, isRoot 
 				continue
 			}
 
+			// Flatten the top-level "properties" bag into separate variables.
+			if isRoot && k == "properties" && prop.Value.Type != nil && slices.Contains(*prop.Value.Type, "object") && len(prop.Value.Properties) > 0 {
+				childValue := constructFlattenedRootPropertiesValue(prop.Value, accessPath)
+				attrs = append(attrs, hclwrite.ObjectAttrTokens{
+					Name:  tokensForObjectKey(k),
+					Value: childValue,
+				})
+				continue
+			}
+
 			snakeName := toSnakeCase(k)
 			var childAccess hclwrite.Tokens
 			childAccess = append(childAccess, accessPath...)
@@ -287,7 +469,7 @@ func constructValue(schema *openapi3.Schema, accessPath hclwrite.Tokens, isRoot 
 
 			childValue := constructValue(prop.Value, childAccess, false)
 			attrs = append(attrs, hclwrite.ObjectAttrTokens{
-				Name:  hclwrite.TokensForIdentifier(k),
+				Name:  tokensForObjectKey(k),
 				Value: childValue,
 			})
 		}
@@ -446,40 +628,86 @@ func buildNestedDescription(schema *openapi3.Schema, indent string) string {
 func toSnakeCase(input string) string {
 	var sb strings.Builder
 	runes := []rune(input)
-	for i, r := range runes {
-		if unicode.IsUpper(r) {
-			if i == 0 {
-				sb.WriteRune(unicode.ToLower(r))
-				continue
-			}
-			prev := runes[i-1]
-			if unicode.IsLower(prev) || unicode.IsDigit(prev) {
-				sb.WriteRune('_')
-			}
-			if unicode.IsUpper(prev) {
-				// Check if we should split here
-				// Standard rule: split if next is lower
-				if i+1 < len(runes) && unicode.IsLower(runes[i+1]) {
-					// Exception: if the lower part is just 's' (plural acronym), don't split.
-					// Look ahead for lower case sequence
-					j := i + 1
-					for j < len(runes) && unicode.IsLower(runes[j]) {
-						j++
-					}
-					lowerLen := j - (i + 1)
 
-					if lowerLen > 1 {
-						sb.WriteRune('_')
-					}
-					if lowerLen == 1 && runes[i+1] != 's' {
-						sb.WriteRune('_')
+	prevWasUnderscore := false
+	wroteAny := false
+
+	isAlnum := func(r rune) bool {
+		return unicode.IsLetter(r) || unicode.IsDigit(r)
+	}
+	prevAlnum := func(i int) (rune, bool) {
+		for j := i - 1; j >= 0; j-- {
+			if isAlnum(runes[j]) {
+				return runes[j], true
+			}
+		}
+		return 0, false
+	}
+	nextAlnum := func(i int) (rune, bool) {
+		for j := i + 1; j < len(runes); j++ {
+			if isAlnum(runes[j]) {
+				return runes[j], true
+			}
+		}
+		return 0, false
+	}
+
+	for i, r := range runes {
+		// Treat non-alphanumerics (e.g. '-', '.', spaces) as separators.
+		if !isAlnum(r) {
+			if wroteAny && !prevWasUnderscore {
+				sb.WriteRune('_')
+				prevWasUnderscore = true
+			}
+			continue
+		}
+
+		if unicode.IsUpper(r) {
+			if p, ok := prevAlnum(i); ok {
+				if (unicode.IsLower(p) || unicode.IsDigit(p)) && !prevWasUnderscore {
+					sb.WriteRune('_')
+				}
+				if unicode.IsUpper(p) {
+					// Split acronyms when the next alnum is lower (HTTPClient -> http_client)
+					if n, ok := nextAlnum(i); ok && unicode.IsLower(n) {
+						// Look ahead for a lower-case sequence length
+						j := i + 1
+						for j < len(runes) {
+							if !isAlnum(runes[j]) {
+								j++
+								continue
+							}
+							if !unicode.IsLower(runes[j]) {
+								break
+							}
+							j++
+						}
+						lowerLen := j - (i + 1)
+
+						if lowerLen > 1 && !prevWasUnderscore {
+							sb.WriteRune('_')
+						}
+						if lowerLen == 1 && n != 's' && !prevWasUnderscore {
+							sb.WriteRune('_')
+						}
 					}
 				}
 			}
 		}
+
 		sb.WriteRune(unicode.ToLower(r))
+		wroteAny = true
+		prevWasUnderscore = false
 	}
-	return sb.String()
+
+	out := strings.Trim(sb.String(), "_")
+	if out == "" {
+		return out
+	}
+	if len(out) > 0 && out[0] >= '0' && out[0] <= '9' {
+		out = "field_" + out
+	}
+	return out
 }
 
 // SupportsTags reports whether the schema includes a writable "tags" property, following allOf inheritance.
@@ -544,7 +772,7 @@ func cleanTypeString(typeStr string) string {
 	return strings.Join(cleaned, "/")
 }
 
-func generateMain(resourceType, apiVersion, localName string, supportsTags, supportsLocation, hasSchema bool) error {
+func generateMain(schema *openapi3.Schema, resourceType, apiVersion, localName string, supportsTags, supportsLocation, hasSchema bool) error {
 	file := hclwrite.NewEmptyFile()
 	body := file.Body()
 
@@ -566,14 +794,21 @@ func generateMain(resourceType, apiVersion, localName string, supportsTags, supp
 
 	resourceBody.SetAttributeValue("body", cty.EmptyObjectVal)
 	if hasSchema {
-		resourceBody.SetAttributeRaw("body", hclwrite.TokensForObject(
-			[]hclwrite.ObjectAttrTokens{
-				{
-					Name:  hclwrite.TokensForIdentifier("properties"),
-					Value: hclgen.TokensForTraversal("local", localName),
+		// If the schema already has a top-level "properties" field, we are generating the full resource body.
+		// Otherwise, we assume the schema itself represents the properties object (e.g. -root properties).
+		_, hasTopLevelProperties := schema.Properties["properties"]
+		if hasTopLevelProperties {
+			resourceBody.SetAttributeRaw("body", hclgen.TokensForTraversal("local", localName))
+		} else {
+			resourceBody.SetAttributeRaw("body", hclwrite.TokensForObject(
+				[]hclwrite.ObjectAttrTokens{
+					{
+						Name:  hclwrite.TokensForIdentifier("properties"),
+						Value: hclgen.TokensForTraversal("local", localName),
+					},
 				},
-			},
-		))
+			))
+		}
 	}
 
 	if supportsTags {

--- a/pkg/terraform/generator_test.go
+++ b/pkg/terraform/generator_test.go
@@ -23,6 +23,9 @@ func TestToSnakeCase(t *testing.T) {
 		{"camelCase", "camel_case"},
 		{"PascalCase", "pascal_case"},
 		{"snake_case", "snake_case"},
+		{"balance-similar-node-groups", "balance_similar_node_groups"},
+		{"foo.bar", "foo_bar"},
+		{"foo bar", "foo_bar"},
 		{"HTTPClient", "http_client"},
 		{"simple", "simple"},
 		{"agentPoolProfiles", "agent_pool_profiles"},
@@ -104,22 +107,21 @@ func TestGenerate(t *testing.T) {
 	assert.Equal(t, "The location of the resource.\n", attributeStringValue(t, locationVar.Body.Attributes["description"]))
 	assert.Equal(t, "string", expressionString(t, locationVar.Body.Attributes["type"].Expr))
 
-	propertiesVar := requireBlock(t, varsBody, "variable", "properties")
-	desc := attributeStringValue(t, propertiesVar.Body.Attributes["description"])
-	assert.Contains(t, desc, "The properties of the resource.")
-	assert.Contains(t, desc, "writable_prop")
-	typeExpr := expressionString(t, propertiesVar.Body.Attributes["type"].Expr)
-	assert.Contains(t, typeExpr, "writable_prop")
-	assert.NotContains(t, typeExpr, "read_only_prop")
-	assert.Equal(t, "null", expressionString(t, propertiesVar.Body.Attributes["default"].Expr))
+	propertiesVar := findBlock(varsBody, "variable", "properties")
+	assert.Nil(t, propertiesVar)
+
+	writableVar := requireBlock(t, varsBody, "variable", "writable_prop")
+	assert.Equal(t, "string", expressionString(t, writableVar.Body.Attributes["type"].Expr))
+	assert.Equal(t, "null", expressionString(t, writableVar.Body.Attributes["default"].Expr))
 
 	localsBody := parseHCLBody(t, "locals.tf")
 	localsBlock := requireBlock(t, localsBody, "locals")
 	localAttr := localsBlock.Body.Attributes["test_local"]
 	localExpr := expressionString(t, localAttr.Expr)
 	assert.Contains(t, localExpr, "location = var.location")
-	assert.Contains(t, localExpr, "writableProp = var.properties.writable_prop")
+	assert.Contains(t, localExpr, "writableProp = var.writable_prop")
 	assert.NotContains(t, localExpr, "readOnlyProp")
+	assert.NotContains(t, localExpr, "var.properties")
 
 	mainBody := parseHCLBody(t, "main.tf")
 	resourceBlock := requireBlock(t, mainBody, "resource", "azapi_resource", "this")
@@ -128,7 +130,7 @@ func TestGenerate(t *testing.T) {
 	assert.Equal(t, "var.parent_id", expressionString(t, resourceBlock.Body.Attributes["parent_id"].Expr))
 	assert.Equal(t, "var.location", expressionString(t, resourceBlock.Body.Attributes["location"].Expr))
 	bodyExpr := expressionString(t, resourceBlock.Body.Attributes["body"].Expr)
-	assert.Contains(t, bodyExpr, "properties = local.test_local")
+	assert.Equal(t, "local.test_local", strings.TrimSpace(bodyExpr))
 	assert.Nil(t, resourceBlock.Body.Attributes["tags"])
 
 	outputsBody := parseHCLBody(t, "outputs.tf")
@@ -139,6 +141,90 @@ func TestGenerate(t *testing.T) {
 	nameOutput := requireBlock(t, outputsBody, "output", "name")
 	assert.Equal(t, "The name of the created resource.", attributeStringValue(t, nameOutput.Body.Attributes["description"]))
 	assert.Equal(t, "azapi_resource.this.name", expressionString(t, nameOutput.Body.Attributes["value"].Expr))
+}
+
+func TestGenerate_QuotesNonIdentifierObjectKeysInLocals(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalWd)
+
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
+
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: map[string]*openapi3.SchemaRef{
+			"properties": {
+				Value: &openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: map[string]*openapi3.SchemaRef{
+						"autoScalerProfile": {
+							Value: &openapi3.Schema{
+								Type: &openapi3.Types{"object"},
+								Properties: map[string]*openapi3.SchemaRef{
+									"balance-similar-node-groups": {
+										Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+									},
+									"foo.bar": {
+										Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	apiVersion := "2025-10-01"
+	err = Generate(schema, "Microsoft.ContainerService/managedClusters", "resource_body", apiVersion, false, false)
+	require.NoError(t, err)
+
+	localsBytes, err := os.ReadFile("locals.tf")
+	require.NoError(t, err)
+	locals := string(localsBytes)
+
+	// Hyphenated keys don't need quotes in HCL.
+	assert.Contains(t, locals, "balance-similar-node-groups")
+	// RHS must reference a valid Terraform attribute name (snake_case).
+	assert.Contains(t, locals, "var.auto_scaler_profile.balance_similar_node_groups")
+
+	// Keys containing '.' must be quoted, otherwise HCL treats '.' as traversal syntax.
+	assert.Contains(t, locals, "\"foo.bar\"")
+	assert.Contains(t, locals, "var.auto_scaler_profile.foo_bar")
+}
+
+func TestGenerate_FailsOnFlattenedPropertiesNameCollision(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalWd)
+
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
+
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: map[string]*openapi3.SchemaRef{
+			"properties": {
+				Value: &openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: map[string]*openapi3.SchemaRef{
+						// This would collide with the built-in top-level var "name".
+						"name": {Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+					},
+				},
+			},
+		},
+	}
+
+	err = Generate(schema, "testResource", "resource_body", "2025-01-01", false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "collision")
 }
 
 func TestGenerate_IncludesAdditionalPropertiesDescription(t *testing.T) {


### PR DESCRIPTION
This pull request improves the Terraform code generation tool by flattening OpenAPI top-level `properties` into idiomatic top-level Terraform variables.

**Terraform Variable Generation & Schema Flattening:**

* Refactored the variable generation logic in `generator.go` to flatten the OpenAPI top-level `properties` object into individual top-level Terraform variables, rather than nesting them under a single `properties` variable. This includes collision detection and improved variable naming using a more robust `toSnakeCase` function. [[1]](diffhunk://#diff-d2e06d132859c0c6c77370d46b8f20b0348eb49598fa4c3f1009221d247fee4aL71-L126) [[2]](diffhunk://#diff-d2e06d132859c0c6c77370d46b8f20b0348eb49598fa4c3f1009221d247fee4aL162-R128) [[3]](diffhunk://#diff-d2e06d132859c0c6c77370d46b8f20b0348eb49598fa4c3f1009221d247fee4aR162-R279) [[4]](diffhunk://#diff-d2e06d132859c0c6c77370d46b8f20b0348eb49598fa4c3f1009221d247fee4aR631-R710) [[5]](diffhunk://#diff-d2e06d132859c0c6c77370d46b8f20b0348eb49598fa4c3f1009221d247fee4aL547-R775)
* Updated the locals generation logic to reconstruct the JSON `properties` object from the flattened variables, and added logic to null out the object when all child variables are unset. [[1]](diffhunk://#diff-d2e06d132859c0c6c77370d46b8f20b0348eb49598fa4c3f1009221d247fee4aR305-R402) [[2]](diffhunk://#diff-d2e06d132859c0c6c77370d46b8f20b0348eb49598fa4c3f1009221d247fee4aR454-R463) [[3]](diffhunk://#diff-d2e06d132859c0c6c77370d46b8f20b0348eb49598fa4c3f1009221d247fee4aL290-R472)

**Resource Generation and Schema Handling:**

* Changed the main resource generation to detect and handle whether the schema has a top-level `properties` field, ensuring the generated `main.tf` uses the correct structure for both full resource and sub-property generation modes. [[1]](diffhunk://#diff-d2e06d132859c0c6c77370d46b8f20b0348eb49598fa4c3f1009221d247fee4aL33-R33) [[2]](diffhunk://#diff-d2e06d132859c0c6c77370d46b8f20b0348eb49598fa4c3f1009221d247fee4aL547-R775) [[3]](diffhunk://#diff-d2e06d132859c0c6c77370d46b8f20b0348eb49598fa4c3f1009221d247fee4aR797-R802) [[4]](diffhunk://#diff-d2e06d132859c0c6c77370d46b8f20b0348eb49598fa4c3f1009221d247fee4aR812)

**Documentation Updates:**

* Updated the `README.md` to document the new flattening behavior, provide new usage examples, and clarify how the tool maps OpenAPI schemas to Terraform variables and locals. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R74) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108-R111)

**Testing Improvements:**

* Expanded and updated tests in `generator_test.go` to verify the flattening of `properties`, improved variable naming, and correct locals generation. [[1]](diffhunk://#diff-118c5b4bdc7a356536483fc150f8df1e4687ef32ba0dfa20a11d3c20e8d41328R26-R28) [[2]](diffhunk://#diff-118c5b4bdc7a356536483fc150f8df1e4687ef32ba0dfa20a11d3c20e8d41328L107-R124)
