### PR TITLE
feat: add application gateway fix to cope with API behaviour

### DIFF
--- a/cmd/tfmodmake/addchild_test.go
+++ b/cmd/tfmodmake/addchild_test.go
@@ -120,7 +120,7 @@ func TestGenerateChildModuleIdempotency(t *testing.T) {
 	modulePath := filepath.Join(tmpDir, "modules", "children")
 
 	// First generation
-	if err := generateChildModule(context.Background(), []string{specPath}, "Microsoft.Test/parents/children", modulePath); err != nil {
+	if err := generateChildModule(context.Background(), []string{specPath}, "Microsoft.Test/parents/children", modulePath, nil); err != nil {
 		t.Fatalf("First generation failed: %v", err)
 	}
 
@@ -137,7 +137,7 @@ func TestGenerateChildModuleIdempotency(t *testing.T) {
 	}
 
 	// Second generation (idempotency test)
-	if err := generateChildModule(context.Background(), []string{specPath}, "Microsoft.Test/parents/children", modulePath); err != nil {
+	if err := generateChildModule(context.Background(), []string{specPath}, "Microsoft.Test/parents/children", modulePath, nil); err != nil {
 		t.Fatalf("Second generation failed: %v", err)
 	}
 

--- a/cmd/tfmodmake/gen.go
+++ b/cmd/tfmodmake/gen.go
@@ -33,6 +33,10 @@ func GenCommand() *cli.Command {
 				Name:  "local-name",
 				Usage: "Name of the local variable to generate (default: resource_body)",
 			},
+			&cli.StringSliceFlag{
+				Name:  "hack",
+				Usage: "Enable a named workaround for a known API spec deficiency (e.g. suppress-inline-id)",
+			},
 		},
 		Action: runGen,
 		Commands: []*cli.Command{
@@ -80,6 +84,10 @@ func GenCommand() *cli.Command {
 						Name:  "dry-run",
 						Usage: "Print planned actions without writing files",
 					},
+					&cli.StringSliceFlag{
+						Name:  "hack",
+						Usage: "Enable a named workaround for a known API spec deficiency (e.g. suppress-inline-id)",
+					},
 				},
 				Action: runAddChild,
 			},
@@ -121,6 +129,10 @@ func GenCommand() *cli.Command {
 						Name:  "dry-run",
 						Usage: "Print planned actions without writing files",
 					},
+					&cli.StringSliceFlag{
+						Name:  "hack",
+						Usage: "Enable a named workaround for a known API spec deficiency (e.g. suppress-inline-id)",
+					},
 				},
 				Action: runGenAVM,
 			},
@@ -132,12 +144,18 @@ func runGen(ctx context.Context, cmd *cli.Command) error {
 	specs := cmd.StringSlice("spec")
 	resourceType := cmd.String("resource")
 	localName := cmd.String("local-name")
+	hackNames := cmd.StringSlice("hack")
 
 	if len(specs) == 0 || resourceType == "" {
 		return cli.ShowSubcommandHelp(cmd)
 	}
 
-	return generateBaseModule(ctx, specs, resourceType, localName)
+	hacks, err := terraform.ParseHacks(hackNames)
+	if err != nil {
+		return err
+	}
+
+	return generateBaseModule(ctx, specs, resourceType, localName, hacks)
 }
 
 func runAddChild(ctx context.Context, cmd *cli.Command) error {
@@ -150,6 +168,7 @@ func runAddChild(ctx context.Context, cmd *cli.Command) error {
 	moduleDir := cmd.String("module-dir")
 	moduleName := cmd.String("module-name")
 	dryRun := cmd.Bool("dry-run")
+	hackNames := cmd.StringSlice("hack")
 
 	if len(specs) == 0 && specRoot == "" {
 		return fmt.Errorf("at least one -spec or -spec-root is required")
@@ -211,7 +230,12 @@ func runAddChild(ctx context.Context, cmd *cli.Command) error {
 		return nil
 	}
 
-	if err := generateChildModule(ctx, specSources, child, modulePath); err != nil {
+	hacks, err := terraform.ParseHacks(hackNames)
+	if err != nil {
+		return err
+	}
+
+	if err := generateChildModule(ctx, specSources, child, modulePath, hacks); err != nil {
 		return fmt.Errorf("failed to generate child module: %w", err)
 	}
 
@@ -233,6 +257,7 @@ func runGenAVM(ctx context.Context, cmd *cli.Command) error {
 	localName := cmd.String("local-name")
 	moduleDir := cmd.String("module-dir")
 	dryRun := cmd.Bool("dry-run")
+	hackNames := cmd.StringSlice("hack")
 
 	if len(specs) == 0 && specRoot == "" {
 		return fmt.Errorf("at least one -spec or -spec-root is required")
@@ -271,6 +296,11 @@ func runGenAVM(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("no specs resolved. Please provide -spec or -spec-root")
 	}
 
+	hacks, err := terraform.ParseHacks(hackNames)
+	if err != nil {
+		return err
+	}
+
 	if dryRun {
 		fmt.Println("DRY RUN: Would execute the following steps:")
 		fmt.Printf("1. Generate base module for resource: %s\n", resourceType)
@@ -281,7 +311,7 @@ func runGenAVM(ctx context.Context, cmd *cli.Command) error {
 		return nil
 	}
 
-	if err := orchestrateAVMGeneration(ctx, specSources, resourceType, localName, moduleDir); err != nil {
+	if err := orchestrateAVMGeneration(ctx, specSources, resourceType, localName, moduleDir, hacks); err != nil {
 		return fmt.Errorf("failed to generate AVM module: %w", err)
 	}
 
@@ -290,7 +320,7 @@ func runGenAVM(ctx context.Context, cmd *cli.Command) error {
 }
 
 // generateChildModule generates a child module scaffold at the specified path.
-func generateChildModule(ctx context.Context, specs []string, childType, modulePath string) error {
+func generateChildModule(ctx context.Context, specs []string, childType, modulePath string, hacks terraform.HackSet) error {
 	// Create module directory if it doesn't exist
 	if err := os.MkdirAll(modulePath, 0o755); err != nil {
 		return fmt.Errorf("failed to create module directory: %w", err)
@@ -318,6 +348,7 @@ func generateChildModule(ctx context.Context, specs []string, childType, moduleP
 		terraform.WithLocalName(localName),
 		terraform.WithModuleNamePrefix(moduleName),
 		terraform.WithOutputDir(modulePath),
+		terraform.WithHacks(hacks),
 	); err != nil {
 		return fmt.Errorf("failed to generate terraform files: %w", err)
 	}
@@ -326,10 +357,10 @@ func generateChildModule(ctx context.Context, specs []string, childType, moduleP
 }
 
 // orchestrateAVMGeneration performs the full AVM generation workflow
-func orchestrateAVMGeneration(ctx context.Context, specSources []string, resourceType, localName, moduleDir string) error {
+func orchestrateAVMGeneration(ctx context.Context, specSources []string, resourceType, localName, moduleDir string, hacks terraform.HackSet) error {
 	// Step 1: Generate base module
 	fmt.Println("Step 1/4: Generating base module...")
-	if err := generateBaseModule(ctx, specSources, resourceType, localName); err != nil {
+	if err := generateBaseModule(ctx, specSources, resourceType, localName, hacks); err != nil {
 		return fmt.Errorf("failed to generate base module: %w", err)
 	}
 
@@ -366,7 +397,7 @@ func orchestrateAVMGeneration(ctx context.Context, specSources []string, resourc
 			modulePath := filepath.Join(moduleDir, moduleName)
 
 			// Generate child module
-			if err := generateChildModule(ctx, specSources, child.ResourceType, modulePath); err != nil {
+			if err := generateChildModule(ctx, specSources, child.ResourceType, modulePath, hacks); err != nil {
 				return fmt.Errorf("failed to generate child module for %s: %w", child.ResourceType, err)
 			}
 
@@ -412,7 +443,7 @@ func isInterfaceManagedChild(childResourceType string) bool {
 }
 
 // generateBaseModule generates the base module files in the current directory
-func generateBaseModule(ctx context.Context, specSources []string, resourceType, localName string) error {
+func generateBaseModule(ctx context.Context, specSources []string, resourceType, localName string, hacks terraform.HackSet) error {
 	// Load the resource from specs
 	result, err := terraform.LoadResource(ctx, specSources, resourceType)
 	if err != nil {
@@ -429,5 +460,6 @@ func generateBaseModule(ctx context.Context, specSources []string, resourceType,
 	return terraform.Generate(resourceType,
 		result,
 		terraform.WithLocalName(finalLocalName),
+		terraform.WithHacks(hacks),
 	)
 }

--- a/scripts/test_examples.sh
+++ b/scripts/test_examples.sh
@@ -97,4 +97,14 @@ WORKDIRS+=("$workdir")
 (cd "$workdir" && terraform validate -no-color >/dev/null)
 echo "ok"
 
+echo "== applicationGateways (gen avm) =="
+workdir="$(mktemp -d -t tfmodmake_example.XXXXXX)"
+WORKDIRS+=("$workdir")
+(cd "$workdir" && "$TFMODMAKE_BIN" gen avm \
+  -spec "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/network/resource-manager/Microsoft.Network/stable/2025-03-01/applicationGateway.json" \
+  -resource Microsoft.Network/applicationGateways >/dev/null)
+(cd "$workdir" && terraform init -backend=false -input=false -no-color >/dev/null)
+(cd "$workdir" && terraform validate -no-color >/dev/null)
+echo "ok"
+
 run_keyvault_case

--- a/scripts/test_examples.sh
+++ b/scripts/test_examples.sh
@@ -97,4 +97,15 @@ WORKDIRS+=("$workdir")
 (cd "$workdir" && terraform validate -no-color >/dev/null)
 echo "ok"
 
+echo "== applicationGateways (gen avm) =="
+workdir="$(mktemp -d -t tfmodmake_example.XXXXXX)"
+WORKDIRS+=("$workdir")
+(cd "$workdir" && "$TFMODMAKE_BIN" gen avm \
+  -spec "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/network/resource-manager/Microsoft.Network/stable/2025-03-01/applicationGateway.json" \
+  -resource Microsoft.Network/applicationGateways \
+  -hack suppress-inline-id >/dev/null)
+(cd "$workdir" && terraform init -backend=false -input=false -no-color >/dev/null)
+(cd "$workdir" && terraform validate -no-color >/dev/null)
+echo "ok"
+
 run_keyvault_case

--- a/terraform/generate_locals.go
+++ b/terraform/generate_locals.go
@@ -14,7 +14,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func generateLocals(schema *openapi3.Schema, localName string, supportsIdentity bool, secrets []secretField, resourceType string, caps openapi.InterfaceCapabilities, moduleNamePrefix string, outputDir string) error {
+func generateLocals(schema *openapi3.Schema, localName string, supportsIdentity bool, secrets []secretField, resourceType string, caps openapi.InterfaceCapabilities, moduleNamePrefix string, outputDir string, hacks HackSet) error {
 	if schema == nil {
 		return nil
 	}
@@ -26,7 +26,7 @@ func generateLocals(schema *openapi3.Schema, localName string, supportsIdentity 
 	localBody := locals.Body()
 
 	secretPaths := newSecretPathSet(secrets)
-	valueExpression, err := constructValue(schema, hclwrite.TokensForIdentifier("var"), true, secretPaths, "", supportsIdentity, moduleNamePrefix)
+	valueExpression, err := constructValue(schema, hclwrite.TokensForIdentifier("var"), true, secretPaths, "", supportsIdentity, moduleNamePrefix, hacks)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func generateLocals(schema *openapi3.Schema, localName string, supportsIdentity 
 	return hclgen.WriteFileToDir(outputDir, "locals.tf", file)
 }
 
-func constructFlattenedRootPropertiesValue(schema *openapi3.Schema, accessPath hclwrite.Tokens, secretPaths map[string]struct{}, moduleNamePrefix string) (hclwrite.Tokens, error) {
+func constructFlattenedRootPropertiesValue(schema *openapi3.Schema, accessPath hclwrite.Tokens, secretPaths map[string]struct{}, moduleNamePrefix string, hacks HackSet) (hclwrite.Tokens, error) {
 	// schema represents the OpenAPI schema at root.properties.
 	// The Terraform variables are flattened to var.<child> rather than var.properties.<child>.
 
@@ -74,7 +74,7 @@ func constructFlattenedRootPropertiesValue(schema *openapi3.Schema, accessPath h
 		if prop == nil || prop.Value == nil {
 			continue
 		}
-		if !isWritableProperty(prop.Value) {
+		if !isWritablePropertyInContext(k, prop.Value, effectiveProps, hacks) {
 			continue
 		}
 
@@ -94,7 +94,7 @@ func constructFlattenedRootPropertiesValue(schema *openapi3.Schema, accessPath h
 		childAccess = append(childAccess, &hclwrite.Token{Type: hclsyntax.TokenDot, Bytes: []byte(".")})
 		childAccess = append(childAccess, hclwrite.TokensForIdentifier(snakeName)...)
 
-		childValue, err := constructValue(prop.Value, childAccess, false, secretPaths, "properties."+k, false, moduleNamePrefix)
+		childValue, err := constructValue(prop.Value, childAccess, false, secretPaths, "properties."+k, false, moduleNamePrefix, hacks)
 		if err != nil {
 			return nil, err
 		}
@@ -107,7 +107,7 @@ func constructFlattenedRootPropertiesValue(schema *openapi3.Schema, accessPath h
 	return hclwrite.TokensForObject(attrs), nil
 }
 
-func constructValue(schema *openapi3.Schema, accessPath hclwrite.Tokens, isRoot bool, secretPaths map[string]struct{}, pathPrefix string, omitRootIdentity bool, moduleNamePrefix string) (hclwrite.Tokens, error) {
+func constructValue(schema *openapi3.Schema, accessPath hclwrite.Tokens, isRoot bool, secretPaths map[string]struct{}, pathPrefix string, omitRootIdentity bool, moduleNamePrefix string, hacks HackSet) (hclwrite.Tokens, error) {
 	if schema.Type == nil {
 		return accessPath, nil
 	}
@@ -117,7 +117,7 @@ func constructValue(schema *openapi3.Schema, accessPath hclwrite.Tokens, isRoot 
 	if slices.Contains(types, "object") {
 		if len(schema.Properties) == 0 {
 			if schema.AdditionalProperties.Schema != nil && schema.AdditionalProperties.Schema.Value != nil {
-				mappedValue, err := constructValue(schema.AdditionalProperties.Schema.Value, hclwrite.TokensForIdentifier("value"), false, secretPaths, pathPrefix, false, moduleNamePrefix)
+				mappedValue, err := constructValue(schema.AdditionalProperties.Schema.Value, hclwrite.TokensForIdentifier("value"), false, secretPaths, pathPrefix, false, moduleNamePrefix, hacks)
 				if err != nil {
 					return nil, err
 				}
@@ -175,7 +175,7 @@ func constructValue(schema *openapi3.Schema, accessPath hclwrite.Tokens, isRoot 
 				continue
 			}
 
-			if !isWritableProperty(prop.Value) {
+			if !isWritablePropertyInContext(k, prop.Value, effectiveProps, hacks) {
 				continue
 			}
 
@@ -191,7 +191,7 @@ func constructValue(schema *openapi3.Schema, accessPath hclwrite.Tokens, isRoot 
 
 			// Flatten the top-level "properties" bag into separate variables.
 			if isRoot && k == "properties" && prop.Value.Type != nil && slices.Contains(*prop.Value.Type, "object") && len(prop.Value.Properties) > 0 {
-				childValue, err := constructFlattenedRootPropertiesValue(prop.Value, accessPath, secretPaths, moduleNamePrefix)
+				childValue, err := constructFlattenedRootPropertiesValue(prop.Value, accessPath, secretPaths, moduleNamePrefix, hacks)
 				if err != nil {
 					return nil, err
 				}
@@ -208,7 +208,7 @@ func constructValue(schema *openapi3.Schema, accessPath hclwrite.Tokens, isRoot 
 			childAccess = append(childAccess, &hclwrite.Token{Type: hclsyntax.TokenDot, Bytes: []byte(".")})
 			childAccess = append(childAccess, hclwrite.TokensForIdentifier(snakeName)...)
 
-			childValue, err := constructValue(prop.Value, childAccess, false, secretPaths, childPath, false, moduleNamePrefix)
+			childValue, err := constructValue(prop.Value, childAccess, false, secretPaths, childPath, false, moduleNamePrefix, hacks)
 			if err != nil {
 				return nil, err
 			}
@@ -227,7 +227,7 @@ func constructValue(schema *openapi3.Schema, accessPath hclwrite.Tokens, isRoot 
 
 	if slices.Contains(types, "array") {
 		if schema.Items != nil && schema.Items.Value != nil {
-			childValue, err := constructValue(schema.Items.Value, hclwrite.TokensForIdentifier("item"), false, secretPaths, pathPrefix+"[]", false, moduleNamePrefix)
+			childValue, err := constructValue(schema.Items.Value, hclwrite.TokensForIdentifier("item"), false, secretPaths, pathPrefix+"[]", false, moduleNamePrefix, hacks)
 			if err != nil {
 				return nil, err
 			}

--- a/terraform/generate_variables.go
+++ b/terraform/generate_variables.go
@@ -15,7 +15,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, supportsIdentity bool, secrets []secretField, nameSchema *openapi3.Schema, caps openapi.InterfaceCapabilities, moduleNamePrefix string, outputDir string) error {
+func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, supportsIdentity bool, secrets []secretField, nameSchema *openapi3.Schema, caps openapi.InterfaceCapabilities, moduleNamePrefix string, outputDir string, hacks HackSet) error {
 	file := hclwrite.NewEmptyFile()
 	body := file.Body()
 
@@ -37,11 +37,11 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 		if err != nil {
 			return false, fmt.Errorf("getting effective properties for array item schema: %w", err)
 		}
-		for _, prop := range props {
+		for propName, prop := range props {
 			if prop == nil || prop.Value == nil {
 				continue
 			}
-			if !isWritableProperty(prop.Value) {
+			if !isWritablePropertyInContext(propName, prop.Value, props, hacks) {
 				continue
 			}
 			if isSecretField(prop.Value) {
@@ -77,7 +77,7 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 			return nil, nil
 		}
 
-		tfType, err := mapType(propSchema)
+		tfType, err := mapType(propSchema, hacks)
 		if err != nil {
 			return nil, err
 		}
@@ -115,7 +115,7 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 				sb.WriteString("Map values:\n")
 			}
 
-			nested, err := buildNestedDescription(nestedDocSchema, "")
+			nested, err := buildNestedDescription(nestedDocSchema, "", hacks)
 			if err != nil {
 				return nil, err
 			}
@@ -302,7 +302,7 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 					continue
 				}
 				childSchema := childRef.Value
-				if !isWritableProperty(childSchema) {
+				if !isWritablePropertyInContext(childName, childSchema, childProps, hacks) {
 					continue
 				}
 
@@ -335,7 +335,7 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 			continue
 		}
 
-		if !isWritableProperty(propSchema) {
+		if !isWritablePropertyInContext(name, propSchema, effectiveProps, hacks) {
 			continue
 		}
 
@@ -376,7 +376,7 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 			secretBlockAdded = true
 		}
 
-		tfType, err := mapType(secret.schema)
+		tfType, err := mapType(secret.schema, hacks)
 		if err != nil {
 			return err
 		}
@@ -469,7 +469,7 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 	return hclgen.WriteFileToDir(outputDir, "variables.tf", file)
 }
 
-func mapType(schema *openapi3.Schema) (hclwrite.Tokens, error) {
+func mapType(schema *openapi3.Schema, hacks HackSet) (hclwrite.Tokens, error) {
 	if schema.Type == nil {
 		return hclwrite.TokensForIdentifier("any"), nil
 	}
@@ -489,7 +489,7 @@ func mapType(schema *openapi3.Schema) (hclwrite.Tokens, error) {
 		elemType := hclwrite.TokensForIdentifier("any")
 		if schema.Items != nil && schema.Items.Value != nil {
 			var err error
-			elemType, err = mapType(schema.Items.Value)
+			elemType, err = mapType(schema.Items.Value, hacks)
 			if err != nil {
 				return nil, err
 			}
@@ -509,7 +509,7 @@ func mapType(schema *openapi3.Schema) (hclwrite.Tokens, error) {
 
 		if len(effectiveProps) == 0 {
 			if schema.AdditionalProperties.Schema != nil && schema.AdditionalProperties.Schema.Value != nil {
-				valueType, err := mapType(schema.AdditionalProperties.Schema.Value)
+				valueType, err := mapType(schema.AdditionalProperties.Schema.Value, hacks)
 				if err != nil {
 					return nil, err
 				}
@@ -531,10 +531,10 @@ func mapType(schema *openapi3.Schema) (hclwrite.Tokens, error) {
 			if prop == nil || prop.Value == nil {
 				continue
 			}
-			if !isWritableProperty(prop.Value) {
+			if !isWritablePropertyInContext(k, prop.Value, effectiveProps, hacks) {
 				continue
 			}
-			fieldType, err := mapType(prop.Value)
+			fieldType, err := mapType(prop.Value, hacks)
 			if err != nil {
 				return nil, err
 			}
@@ -559,7 +559,7 @@ func mapType(schema *openapi3.Schema) (hclwrite.Tokens, error) {
 	return hclwrite.TokensForIdentifier("any"), nil
 }
 
-func buildNestedDescription(schema *openapi3.Schema, indent string) (string, error) {
+func buildNestedDescription(schema *openapi3.Schema, indent string, hacks HackSet) (string, error) {
 	var sb strings.Builder
 
 	// Get effective properties for allOf handling
@@ -588,7 +588,7 @@ func buildNestedDescription(schema *openapi3.Schema, indent string) (string, err
 		}
 		val := childProp.Value
 
-		if !isWritableProperty(val) {
+		if !isWritablePropertyInContext(k, val, effectiveProps, hacks) {
 			continue
 		}
 
@@ -613,7 +613,7 @@ func buildNestedDescription(schema *openapi3.Schema, indent string) (string, err
 			return "", fmt.Errorf("getting effective properties for nested object: %w", err)
 		}
 		if isNested && len(nestedProps) > 0 {
-			nested, err := buildNestedDescription(val, indent+"  ")
+			nested, err := buildNestedDescription(val, indent+"  ", hacks)
 			if err != nil {
 				return "", err
 			}

--- a/terraform/generator.go
+++ b/terraform/generator.go
@@ -21,6 +21,7 @@ type generatorOptions struct {
 	spec             *openapi3.T
 	moduleNamePrefix string
 	outputDir        string
+	hacks            HackSet
 }
 
 // WithSchema sets the OpenAPI schema for the resource.
@@ -79,6 +80,13 @@ func WithOutputDir(dir string) GeneratorOption {
 	}
 }
 
+// WithHacks sets the enabled hacks for the generator.
+func WithHacks(hacks HackSet) GeneratorOption {
+	return func(o *generatorOptions) {
+		o.hacks = hacks
+	}
+}
+
 // WithLoadResult sets multiple options from a ResourceLoadResult.
 func WithLoadResult(result *ResourceLoadResult) GeneratorOption {
 	return func(o *generatorOptions) {
@@ -129,11 +137,11 @@ func generateWithOpts(o *generatorOptions) error {
 	if err := generateTerraform(o.outputDir); err != nil {
 		return err
 	}
-	if err := generateVariables(o.schema, o.supportsTags, o.supportsLocation, supportsIdentity, secrets, nameSchema, caps, o.moduleNamePrefix, o.outputDir); err != nil {
+	if err := generateVariables(o.schema, o.supportsTags, o.supportsLocation, supportsIdentity, secrets, nameSchema, caps, o.moduleNamePrefix, o.outputDir, o.hacks); err != nil {
 		return err
 	}
 	if hasSchema {
-		if err := generateLocals(o.schema, o.localName, supportsIdentity, secrets, o.resourceType, caps, o.moduleNamePrefix, o.outputDir); err != nil {
+		if err := generateLocals(o.schema, o.localName, supportsIdentity, secrets, o.resourceType, caps, o.moduleNamePrefix, o.outputDir, o.hacks); err != nil {
 			return err
 		}
 	}

--- a/terraform/generator_test.go
+++ b/terraform/generator_test.go
@@ -760,7 +760,7 @@ func TestMapType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotTokens, err := mapType(tt.schema)
+			gotTokens, err := mapType(tt.schema, nil)
 			require.NoError(t, err)
 			got := string(gotTokens.Bytes())
 			assert.Equal(t, tt.want, got)
@@ -785,7 +785,7 @@ func TestBuildNestedDescription(t *testing.T) {
 		},
 	}
 
-	got, err := buildNestedDescription(schema, "")
+	got, err := buildNestedDescription(schema, "", nil)
 	require.NoError(t, err)
 	assert.Contains(t, got, "- `prop1` - Description 1")
 	assert.Contains(t, got, "- `nested` - Nested object")
@@ -821,7 +821,7 @@ func TestConstructValue_MapAdditionalPropertiesObject(t *testing.T) {
 		{Type: hclsyntax.TokenDot, Bytes: []byte(".")},
 		{Type: hclsyntax.TokenIdent, Bytes: []byte("kube_dns_overrides")},
 	}
-	tokens, err := constructValue(schema, accessPath, false, nil, "", false, "")
+	tokens, err := constructValue(schema, accessPath, false, nil, "", false, "", nil)
 	require.NoError(t, err)
 
 	f := hclwrite.NewEmptyFile()

--- a/terraform/hacks.go
+++ b/terraform/hacks.go
@@ -1,0 +1,80 @@
+package terraform
+
+import "github.com/getkin/kin-openapi/openapi3"
+
+// Hack represents a named workaround for a known API spec deficiency.
+// Hacks are opt-in via the --hack CLI flag to keep their effects visible
+// and confined to resources that need them.
+type Hack string
+
+const (
+	// HackSuppressInlineID treats "id" fields as computed (non-writable) when
+	// the parent object also has a "name" sibling property. This works around
+	// Azure specs that fail to mark inline sub-resource ids as readOnly;
+	// the id is derived from the parent resource path + name at deploy time.
+	HackSuppressInlineID Hack = "suppress-inline-id"
+)
+
+// HackSet is a set of enabled hacks.
+type HackSet map[Hack]struct{}
+
+// Has reports whether the hack is enabled in this set.
+func (hs HackSet) Has(h Hack) bool {
+	_, ok := hs[h]
+	return ok
+}
+
+// ParseHacks converts a list of hack name strings into a HackSet.
+// Unknown hack names are returned as errors.
+func ParseHacks(names []string) (HackSet, error) {
+	known := map[string]Hack{
+		string(HackSuppressInlineID): HackSuppressInlineID,
+	}
+
+	hs := make(HackSet, len(names))
+	for _, name := range names {
+		h, ok := known[name]
+		if !ok {
+			return nil, &UnknownHackError{Name: name, Known: knownHackNames(known)}
+		}
+		hs[h] = struct{}{}
+	}
+	return hs, nil
+}
+
+// knownHackNames returns sorted known hack names for error messages.
+func knownHackNames(known map[string]Hack) []string {
+	names := make([]string, 0, len(known))
+	for name := range known {
+		names = append(names, name)
+	}
+	return names
+}
+
+// UnknownHackError is returned when an unrecognized hack name is provided.
+type UnknownHackError struct {
+	Name  string
+	Known []string
+}
+
+func (e *UnknownHackError) Error() string {
+	return "unknown hack: " + e.Name
+}
+
+// isWritablePropertyInContext checks writability considering parent context and enabled hacks.
+// When HackSuppressInlineID is enabled, "id" fields with a "name" sibling are treated as
+// computed (non-writable), working around Azure specs that don't mark inline definition ids
+// as readOnly.
+func isWritablePropertyInContext(propName string, propSchema *openapi3.Schema, siblingProps map[string]*openapi3.SchemaRef, hacks HackSet) bool {
+	if !isWritableProperty(propSchema) {
+		return false
+	}
+
+	if hacks.Has(HackSuppressInlineID) && propName == "id" && siblingProps != nil {
+		if _, hasName := siblingProps["name"]; hasName {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
Deal with the resource ID in app gateway being not labelled writeable, and missing types in property object bags

**Property writability and schema handling improvements:**

* Introduced the new `isWritablePropertyInContext` function in `terraform/writability.go`, which adds context-aware logic for determining if a property is writable—specifically treating `"id"` fields as computed (not writable) when a `"name"` sibling exists, addressing Azure schema quirks. All relevant code now uses this function instead of the previous `isWritableProperty`.
* Updated all usages in `terraform/generate_locals.go` and `terraform/generate_variables.go` to use `isWritablePropertyInContext`, passing property names and sibling property maps for accurate context. [[1]](diffhunk://#diff-ca187cd066b6c65afef61c91a3ab71e54494e74abe6576f71d37735914ab4930L77-R77) [[2]](diffhunk://#diff-ca187cd066b6c65afef61c91a3ab71e54494e74abe6576f71d37735914ab4930L178-R187) [[3]](diffhunk://#diff-15ec01cfb393134112139c655188b9c1081a266ad68317989f4fbe9f8e757a0cL40-R44) [[4]](diffhunk://#diff-15ec01cfb393134112139c655188b9c1081a266ad68317989f4fbe9f8e757a0cL305-R306) [[5]](diffhunk://#diff-15ec01cfb393134112139c655188b9c1081a266ad68317989f4fbe9f8e757a0cL338-R339) [[6]](diffhunk://#diff-15ec01cfb393134112139c655188b9c1081a266ad68317989f4fbe9f8e757a0cL534-R535) [[7]](diffhunk://#diff-15ec01cfb393134112139c655188b9c1081a266ad68317989f4fbe9f8e757a0cL591-R592)

**Schema type and property flattening logic:**

* Improved logic for detecting object types in `constructValue` (in `terraform/generate_locals.go`): now treats schemas with properties as objects even if the explicit type is missing, and uses effective properties (including `allOf` inheritance) for flattening and variable generation. [[1]](diffhunk://#diff-ca187cd066b6c65afef61c91a3ab71e54494e74abe6576f71d37735914ab4930L111-R133) [[2]](diffhunk://#diff-ca187cd066b6c65afef61c91a3ab71e54494e74abe6576f71d37735914ab4930L147-L152) [[3]](diffhunk://#diff-ca187cd066b6c65afef61c91a3ab71e54494e74abe6576f71d37735914ab4930L193-R207) [[4]](diffhunk://#diff-ca187cd066b6c65afef61c91a3ab71e54494e74abe6576f71d37735914ab4930R218) [[5]](diffhunk://#diff-ca187cd066b6c65afef61c91a3ab71e54494e74abe6576f71d37735914ab4930L228-R243) [[6]](diffhunk://#diff-15ec01cfb393134112139c655188b9c1081a266ad68317989f4fbe9f8e757a0cL278-R279)

**Testing and validation:**

* Added a new test case for generating and validating Terraform code for `applicationGateways` using the latest Azure REST API spec in `scripts/test_examples.sh`.