### PR TITLE
feat: add update command for upgrading modules to new API versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ go.work.sum
 # env file
 .env
 
+# OpenCode
+.opencode/
+
 # Editor/IDE
 # .idea/
 # .vscode/

--- a/cmd/tfmodmake/main.go
+++ b/cmd/tfmodmake/main.go
@@ -21,6 +21,7 @@ func main() {
 			DiscoverCommand(),
 			UpdateCommand(),
 		},
+		DefaultCommand: "gen",
 	}
 
 	if err := cmd.Run(context.Background(), os.Args); err != nil {

--- a/cmd/tfmodmake/main.go
+++ b/cmd/tfmodmake/main.go
@@ -19,8 +19,8 @@ func main() {
 			GenCommand(),
 			AddCommand(),
 			DiscoverCommand(),
+			UpdateCommand(),
 		},
-		DefaultCommand: "gen",
 	}
 
 	if err := cmd.Run(context.Background(), os.Args); err != nil {

--- a/cmd/tfmodmake/update.go
+++ b/cmd/tfmodmake/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	specpkg "github.com/matt-FFFFFF/tfmodmake/specs"
 	"github.com/matt-FFFFFF/tfmodmake/terraform"
@@ -60,15 +61,9 @@ func runUpdate(ctx context.Context, cmd *cli.Command) error {
 			return fmt.Errorf("could not infer resource type from main.tf (use --resource to specify): %w", err)
 		}
 		// Strip the @apiVersion suffix if present
-		if idx := len(inferred) - 1; idx >= 0 {
-			for i := len(inferred) - 1; i >= 0; i-- {
-				if inferred[i] == '@' {
-					resourceType = inferred[:i]
-					break
-				}
-			}
-		}
-		if resourceType == "" {
+		if idx := strings.LastIndex(inferred, "@"); idx > 0 {
+			resourceType = inferred[:idx]
+		} else {
 			resourceType = inferred
 		}
 	}
@@ -76,9 +71,42 @@ func runUpdate(ctx context.Context, cmd *cli.Command) error {
 	githubToken := specpkg.GithubTokenFromEnv()
 	includeGlobs := defaultDiscoveryGlobsForParent(resourceType)
 
-	// Resolve specs
+	// Extract the old API version from the existing module's main.tf so we can
+	// resolve the old spec for a proper 3-way comparison.
+	oldVersion, err := extractOldVersionFromMainTf()
+	if err != nil {
+		return fmt.Errorf("could not extract old API version from main.tf: %w", err)
+	}
+
+	// Resolve old specs using PinVersion to get the baseline spec.
+	var oldSpecSources []string
+	if specRoot != "" {
+		resolver := specpkg.DefaultSpecResolver{}
+		oldResolveReq := specpkg.ResolveRequest{
+			GitHubServiceRoot: specRoot,
+			IncludeGlobs:      includeGlobs,
+			PinVersion:        oldVersion,
+			GitHubToken:       githubToken,
+		}
+		oldResolved, resolveErr := resolver.Resolve(ctx, oldResolveReq)
+		if resolveErr != nil {
+			return fmt.Errorf("failed to resolve old specs for version %s: %w", oldVersion, resolveErr)
+		}
+		for _, spec := range oldResolved.Specs {
+			if spec.Source != "" {
+				oldSpecSources = append(oldSpecSources, spec.Source)
+			}
+		}
+	}
+	// If we couldn't resolve old specs via spec-root, fall back to seed specs
+	// (the caller may have provided old specs directly).
+	if len(oldSpecSources) == 0 {
+		oldSpecSources = specs
+	}
+
+	// Resolve new specs (latest version).
 	resolver := specpkg.DefaultSpecResolver{}
-	resolveReq := specpkg.ResolveRequest{
+	newResolveReq := specpkg.ResolveRequest{
 		Seeds:             specs,
 		GitHubServiceRoot: specRoot,
 		DiscoverFromSeed:  false,
@@ -86,26 +114,26 @@ func runUpdate(ctx context.Context, cmd *cli.Command) error {
 		IncludePreview:    includePreview,
 		GitHubToken:       githubToken,
 	}
-	resolved, err := resolver.Resolve(ctx, resolveReq)
+	newResolved, err := resolver.Resolve(ctx, newResolveReq)
 	if err != nil {
-		return fmt.Errorf("failed to resolve specs: %w", err)
+		return fmt.Errorf("failed to resolve new specs: %w", err)
 	}
 
-	specSources := make([]string, 0, len(resolved.Specs))
-	for _, spec := range resolved.Specs {
-		if spec.Source == "" {
-			continue
+	newSpecSources := make([]string, 0, len(newResolved.Specs))
+	for _, spec := range newResolved.Specs {
+		if spec.Source != "" {
+			newSpecSources = append(newSpecSources, spec.Source)
 		}
-		specSources = append(specSources, spec.Source)
 	}
-	if len(specSources) == 0 {
-		return fmt.Errorf("no specs resolved. Please provide --spec or --spec-root")
+	if len(newSpecSources) == 0 {
+		return fmt.Errorf("no new specs resolved. Please provide --spec or --spec-root")
 	}
 
-	// Run update
+	// Run update with separate old and new specs for 3-way comparison.
 	result, err := terraform.Update(ctx, terraform.UpdateOptions{
 		ModuleDir:    ".",
-		NewSpecs:     specSources,
+		OldSpecs:     oldSpecSources,
+		NewSpecs:     newSpecSources,
 		ResourceType: resourceType,
 		DryRun:       dryRun,
 	})
@@ -116,6 +144,19 @@ func runUpdate(ctx context.Context, cmd *cli.Command) error {
 	// Print summary
 	printUpdateSummary(result, dryRun)
 	return nil
+}
+
+// extractOldVersionFromMainTf reads main.tf and extracts the old API version.
+func extractOldVersionFromMainTf() (string, error) {
+	mainFile, err := terraform.ParseModuleFile(".", "main.tf")
+	if err != nil {
+		return "", fmt.Errorf("reading main.tf: %w", err)
+	}
+	_, version, err := terraform.ExtractResourceTypeAndVersion(mainFile)
+	if err != nil {
+		return "", err
+	}
+	return version, nil
 }
 
 func printUpdateSummary(result *terraform.UpdateResult, dryRun bool) {

--- a/cmd/tfmodmake/update.go
+++ b/cmd/tfmodmake/update.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	specpkg "github.com/matt-FFFFFF/tfmodmake/specs"
+	"github.com/matt-FFFFFF/tfmodmake/terraform"
+	"github.com/urfave/cli/v3"
+)
+
+// UpdateCommand returns the CLI command for updating an existing module to a new API version.
+func UpdateCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "update",
+		Aliases: []string{"u"},
+		Usage:   "Update an existing module to a new API version",
+		Flags: []cli.Flag{
+			&cli.StringSliceFlag{
+				Name:  "spec",
+				Usage: "Path or URL to the new OpenAPI spec",
+			},
+			&cli.StringFlag{
+				Name:  "spec-root",
+				Usage: "GitHub tree URL for spec discovery",
+			},
+			&cli.StringFlag{
+				Name:  "resource",
+				Usage: "Resource type (inferred from main.tf if omitted)",
+			},
+			&cli.BoolFlag{
+				Name:  "include-preview",
+				Usage: "Include preview API versions during spec resolution",
+			},
+			&cli.BoolFlag{
+				Name:  "dry-run",
+				Usage: "Print planned changes without modifying files",
+			},
+		},
+		Action: runUpdate,
+	}
+}
+
+func runUpdate(ctx context.Context, cmd *cli.Command) error {
+	specs := cmd.StringSlice("spec")
+	specRoot := cmd.String("spec-root")
+	includePreview := cmd.Bool("include-preview")
+	resourceType := cmd.String("resource")
+	dryRun := cmd.Bool("dry-run")
+
+	if len(specs) == 0 && specRoot == "" {
+		return fmt.Errorf("at least one --spec or --spec-root is required")
+	}
+
+	// If resource type not provided, infer from main.tf
+	if resourceType == "" {
+		inferred, err := inferResourceTypeFromMainTf()
+		if err != nil {
+			return fmt.Errorf("could not infer resource type from main.tf (use --resource to specify): %w", err)
+		}
+		// Strip the @apiVersion suffix if present
+		if idx := len(inferred) - 1; idx >= 0 {
+			for i := len(inferred) - 1; i >= 0; i-- {
+				if inferred[i] == '@' {
+					resourceType = inferred[:i]
+					break
+				}
+			}
+		}
+		if resourceType == "" {
+			resourceType = inferred
+		}
+	}
+
+	githubToken := specpkg.GithubTokenFromEnv()
+	includeGlobs := defaultDiscoveryGlobsForParent(resourceType)
+
+	// Resolve specs
+	resolver := specpkg.DefaultSpecResolver{}
+	resolveReq := specpkg.ResolveRequest{
+		Seeds:             specs,
+		GitHubServiceRoot: specRoot,
+		DiscoverFromSeed:  false,
+		IncludeGlobs:      includeGlobs,
+		IncludePreview:    includePreview,
+		GitHubToken:       githubToken,
+	}
+	resolved, err := resolver.Resolve(ctx, resolveReq)
+	if err != nil {
+		return fmt.Errorf("failed to resolve specs: %w", err)
+	}
+
+	specSources := make([]string, 0, len(resolved.Specs))
+	for _, spec := range resolved.Specs {
+		if spec.Source == "" {
+			continue
+		}
+		specSources = append(specSources, spec.Source)
+	}
+	if len(specSources) == 0 {
+		return fmt.Errorf("no specs resolved. Please provide --spec or --spec-root")
+	}
+
+	// Run update
+	result, err := terraform.Update(ctx, terraform.UpdateOptions{
+		ModuleDir:    ".",
+		NewSpecs:     specSources,
+		ResourceType: resourceType,
+		DryRun:       dryRun,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Print summary
+	printUpdateSummary(result, dryRun)
+	return nil
+}
+
+func printUpdateSummary(result *terraform.UpdateResult, dryRun bool) {
+	prefix := ""
+	if dryRun {
+		prefix = "DRY RUN: "
+	}
+
+	fmt.Printf("%sAPI version: %s -> %s\n\n", prefix, result.OldVersion, result.NewVersion)
+
+	printItemSummary(prefix+"Variables", result.Variables)
+	printItemSummary(prefix+"Locals", result.Locals)
+
+	if result.MainUpdated {
+		fmt.Printf("%sMain: type attribute updated\n", prefix)
+	}
+	if result.OutputsRegenerated {
+		fmt.Printf("%sOutputs: regenerated from new spec\n", prefix)
+	}
+}
+
+func printItemSummary(header string, summary terraform.UpdateSummary) {
+	hasChanges := len(summary.AutoUpdated) > 0 || len(summary.Added) > 0 ||
+		len(summary.Removed) > 0 || len(summary.NeedsReview) > 0
+
+	if !hasChanges {
+		return
+	}
+
+	fmt.Printf("%s:\n", header)
+	printSortedItems("  auto-updated", summary.AutoUpdated)
+	printSortedItems("  added", summary.Added)
+	printSortedItems("  removed", summary.Removed)
+	printSortedItems("  needs review", summary.NeedsReview)
+	fmt.Println()
+}
+
+func printSortedItems(prefix string, items []string) {
+	if len(items) == 0 {
+		return
+	}
+	sorted := make([]string, len(items))
+	copy(sorted, items)
+	sort.Strings(sorted)
+	for _, item := range sorted {
+		fmt.Printf("%s: %s\n", prefix, item)
+	}
+}

--- a/scripts/test_examples.sh
+++ b/scripts/test_examples.sh
@@ -81,6 +81,30 @@ run_keyvault_case() {
   echo "ok"
 }
 
+run_update_case() {
+  echo "== managedClusters (update) =="
+
+  local workdir
+  workdir="$(mktemp -d -t tfmodmake_example.XXXXXX)"
+  WORKDIRS+=("$workdir")
+
+  local stable_spec="https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-10-01/managedClusters.json"
+  local spec_root="https://github.com/Azure/azure-rest-api-specs/tree/main/specification/containerservice/resource-manager/Microsoft.ContainerService/aks"
+  local resource="Microsoft.ContainerService/managedClusters"
+
+  # Step 1: Generate initial module with stable API version
+  (cd "$workdir" && "$TFMODMAKE_BIN" gen -spec "$stable_spec" -resource "$resource" >/dev/null)
+  (cd "$workdir" && terraform init -backend=false -input=false -no-color >/dev/null)
+  (cd "$workdir" && terraform validate -no-color >/dev/null)
+
+  # Step 2: Update to latest preview version
+  (cd "$workdir" && "$TFMODMAKE_BIN" update -spec-root "$spec_root" -include-preview -resource "$resource" >/dev/null)
+  (cd "$workdir" && terraform init -backend=false -input=false -no-color >/dev/null)
+  (cd "$workdir" && terraform validate -no-color >/dev/null)
+
+  echo "ok"
+}
+
 run_case \
   "managedClusters" \
   "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-10-01/managedClusters.json" \
@@ -98,3 +122,5 @@ WORKDIRS+=("$workdir")
 echo "ok"
 
 run_keyvault_case
+
+run_update_case

--- a/specs/spec_discovery.go
+++ b/specs/spec_discovery.go
@@ -506,3 +506,49 @@ func parseAPIVersionDatePrefix(versionName string) (time.Time, bool) {
 	}
 	return t, true
 }
+
+// discoverPinnedVersionSpecsFromGitHubDir locates spec files for a specific API version
+// within a service root directory. It checks both stable/<version> and preview/<version>
+// subdirectories.
+func discoverPinnedVersionSpecsFromGitHubDir(client *http.Client, loc githubLocation, includeGlobs []string, githubToken string, pinVersion string) ([]string, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if len(includeGlobs) == 0 {
+		includeGlobs = []string{"*.json"}
+	}
+
+	// If the directory already points to a version folder containing files, use it.
+	if urls, ok := tryListMatchingFilesInDir(client, loc, includeGlobs, githubToken); ok {
+		return urls, nil
+	}
+
+	// Try stable/<version> and preview/<version> under the service root.
+	candidates := []string{
+		strings.TrimSuffix(loc.Dir, "/") + "/stable/" + pinVersion,
+		strings.TrimSuffix(loc.Dir, "/") + "/preview/" + pinVersion,
+	}
+
+	// Also try inferring from a sibling stability root structure.
+	if stableRoot, previewRoot, ok := inferSiblingStabilityRoots(loc.Dir); ok {
+		candidates = append([]string{
+			stableRoot + "/" + pinVersion,
+			previewRoot + "/" + pinVersion,
+		}, candidates...)
+	}
+
+	seen := make(map[string]struct{})
+	for _, candidate := range candidates {
+		if _, exists := seen[candidate]; exists {
+			continue
+		}
+		seen[candidate] = struct{}{}
+
+		candidateLoc := githubLocation{Owner: loc.Owner, Repo: loc.Repo, Ref: loc.Ref, Dir: candidate}
+		if urls, ok := tryListMatchingFilesInDir(client, candidateLoc, includeGlobs, githubToken); ok {
+			return urls, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no spec files found for version %s under %s", pinVersion, loc.Dir)
+}

--- a/specs/spec_resolver.go
+++ b/specs/spec_resolver.go
@@ -28,6 +28,12 @@ type ResolveRequest struct {
 
 	IncludePreview bool
 
+	// PinVersion, when set, restricts spec resolution to only the version folder
+	// matching this exact API version string (e.g. "2024-02-02-preview").
+	// This is used by the update command to locate the spec for the current
+	// API version embedded in a module's main.tf.
+	PinVersion string
+
 	GitHubToken string
 }
 
@@ -60,16 +66,28 @@ func (r DefaultSpecResolver) Resolve(ctx context.Context, req ResolveRequest) (R
 			return ResolveResult{}, fmt.Errorf("invalid -spec-root: %w", err)
 		}
 
-		// Deterministic by default: treat -spec-root as a service root and select the latest stable
-		// version folder (optionally also include the latest preview folder).
-		urls, err := discoverDeterministicSpecSetFromGitHubDir(nil, loc, req.IncludeGlobs, req.GitHubToken, deterministicDiscoveryOptions{
-			IncludePreview: req.IncludePreview,
-		})
-		if err != nil {
-			return ResolveResult{}, fmt.Errorf("failed to discover specs from -spec-root: %w", err)
-		}
-		for _, url := range urls {
-			out.Specs = append(out.Specs, ResolvedSpec{Source: url, Origin: "spec-root"})
+		if req.PinVersion != "" {
+			// Version-pinned lookup: go directly to the version folder
+			// under stable/ or preview/ that matches the pinned version.
+			urls, err := discoverPinnedVersionSpecsFromGitHubDir(nil, loc, req.IncludeGlobs, req.GitHubToken, req.PinVersion)
+			if err != nil {
+				return ResolveResult{}, fmt.Errorf("failed to discover specs for pinned version %s: %w", req.PinVersion, err)
+			}
+			for _, url := range urls {
+				out.Specs = append(out.Specs, ResolvedSpec{Source: url, Origin: "spec-root-pinned"})
+			}
+		} else {
+			// Deterministic by default: treat -spec-root as a service root and select the latest stable
+			// version folder (optionally also include the latest preview folder).
+			urls, err := discoverDeterministicSpecSetFromGitHubDir(nil, loc, req.IncludeGlobs, req.GitHubToken, deterministicDiscoveryOptions{
+				IncludePreview: req.IncludePreview,
+			})
+			if err != nil {
+				return ResolveResult{}, fmt.Errorf("failed to discover specs from -spec-root: %w", err)
+			}
+			for _, url := range urls {
+				out.Specs = append(out.Specs, ResolvedSpec{Source: url, Origin: "spec-root"})
+			}
 		}
 	}
 

--- a/terraform/compare.go
+++ b/terraform/compare.go
@@ -1,0 +1,112 @@
+package terraform
+
+import (
+	"bytes"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// CompareResult classifies an item during update comparison.
+type CompareResult int
+
+const (
+	// CompareIdentical means the on-disk item matches the baseline (auto-upgradable).
+	CompareIdentical CompareResult = iota
+	// CompareModified means the on-disk item differs from the baseline (user-modified).
+	CompareModified
+	// CompareNew means the item exists in the new spec but not the old.
+	CompareNew
+	// CompareRemoved means the item exists in the old spec but not the new.
+	CompareRemoved
+)
+
+// NormalizeTokens strips whitespace, newlines, and comment tokens to enable
+// format-insensitive comparison of HCL expressions.
+func NormalizeTokens(tokens hclwrite.Tokens) hclwrite.Tokens {
+	out := make(hclwrite.Tokens, 0, len(tokens))
+	for _, tok := range tokens {
+		switch tok.Type {
+		case hclsyntax.TokenNewline, hclsyntax.TokenComment:
+			continue
+		}
+		// Collapse whitespace in token bytes (spaces, tabs) but keep the token
+		// itself since it may carry semantic content.
+		cleaned := bytes.TrimSpace(tok.Bytes)
+		if len(cleaned) == 0 {
+			continue
+		}
+		out = append(out, &hclwrite.Token{
+			Type:  tok.Type,
+			Bytes: cleaned,
+		})
+	}
+	return out
+}
+
+// TokensEqual compares two token sequences after normalization.
+func TokensEqual(a, b hclwrite.Tokens) bool {
+	na := NormalizeTokens(a)
+	nb := NormalizeTokens(b)
+	if len(na) != len(nb) {
+		return false
+	}
+	for i := range na {
+		if na[i].Type != nb[i].Type {
+			return false
+		}
+		if !bytes.Equal(na[i].Bytes, nb[i].Bytes) {
+			return false
+		}
+	}
+	return true
+}
+
+// CompareVariables compares on-disk variable types against baseline generated types
+// and returns per-variable comparison results. The newGenerated map provides the
+// new spec's generated types for detecting additions and removals.
+func CompareVariables(onDisk, baseline, newGenerated map[string]hclwrite.Tokens) map[string]CompareResult {
+	result := make(map[string]CompareResult)
+
+	// Check all items in the new spec
+	for name := range newGenerated {
+		baselineTokens, inBaseline := baseline[name]
+		diskTokens, onDiskExists := onDisk[name]
+
+		if !inBaseline {
+			// New in the new spec
+			result[name] = CompareNew
+			continue
+		}
+
+		if !onDiskExists {
+			// Was in baseline but user deleted it — treat as user-modified so we
+			// don't re-add something they intentionally removed.
+			result[name] = CompareModified
+			continue
+		}
+
+		// Exists in both specs — check if on-disk matches baseline
+		if TokensEqual(diskTokens, baselineTokens) {
+			result[name] = CompareIdentical
+		} else {
+			result[name] = CompareModified
+		}
+	}
+
+	// Check for items in baseline that are not in the new spec (removed)
+	for name := range baseline {
+		if _, inNew := newGenerated[name]; !inNew {
+			result[name] = CompareRemoved
+		}
+	}
+
+	return result
+}
+
+// CompareLocals compares on-disk local assignments against baseline generated locals
+// and returns per-assignment comparison results.
+func CompareLocals(onDisk, baseline, newGenerated map[string]hclwrite.Tokens) map[string]CompareResult {
+	// Same logic as CompareVariables — both operate on name->tokens maps.
+	return CompareVariables(onDisk, baseline, newGenerated)
+}

--- a/terraform/compare_test.go
+++ b/terraform/compare_test.go
@@ -1,0 +1,260 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+func makeToken(typ hclsyntax.TokenType, b string) *hclwrite.Token {
+	return &hclwrite.Token{Type: typ, Bytes: []byte(b)}
+}
+
+func TestNormalizeTokens(t *testing.T) {
+	tests := []struct {
+		name  string
+		input hclwrite.Tokens
+		want  int // expected number of tokens after normalization
+	}{
+		{
+			name:  "empty tokens",
+			input: hclwrite.Tokens{},
+			want:  0,
+		},
+		{
+			name: "strips newline tokens",
+			input: hclwrite.Tokens{
+				makeToken(hclsyntax.TokenIdent, "foo"),
+				makeToken(hclsyntax.TokenNewline, "\n"),
+				makeToken(hclsyntax.TokenIdent, "bar"),
+			},
+			want: 2,
+		},
+		{
+			name: "strips comment tokens",
+			input: hclwrite.Tokens{
+				makeToken(hclsyntax.TokenIdent, "foo"),
+				makeToken(hclsyntax.TokenComment, "# comment"),
+				makeToken(hclsyntax.TokenIdent, "bar"),
+			},
+			want: 2,
+		},
+		{
+			name: "strips whitespace-only tokens",
+			input: hclwrite.Tokens{
+				makeToken(hclsyntax.TokenIdent, "foo"),
+				makeToken(hclsyntax.TokenIdent, "   "),
+				makeToken(hclsyntax.TokenIdent, "bar"),
+			},
+			want: 2,
+		},
+		{
+			name: "trims leading/trailing whitespace from tokens",
+			input: hclwrite.Tokens{
+				makeToken(hclsyntax.TokenIdent, "  foo  "),
+			},
+			want: 1,
+		},
+		{
+			name: "preserves semantic tokens",
+			input: hclwrite.Tokens{
+				makeToken(hclsyntax.TokenIdent, "string"),
+			},
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeTokens(tt.input)
+			if len(got) != tt.want {
+				t.Errorf("NormalizeTokens() returned %d tokens, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeTokens_trimmedContent(t *testing.T) {
+	input := hclwrite.Tokens{
+		makeToken(hclsyntax.TokenIdent, "  foo  "),
+	}
+	got := NormalizeTokens(input)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 token, got %d", len(got))
+	}
+	if string(got[0].Bytes) != "foo" {
+		t.Errorf("expected trimmed bytes %q, got %q", "foo", string(got[0].Bytes))
+	}
+}
+
+func TestTokensEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a    hclwrite.Tokens
+		b    hclwrite.Tokens
+		want bool
+	}{
+		{
+			name: "identical tokens",
+			a:    hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "string")},
+			b:    hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "string")},
+			want: true,
+		},
+		{
+			name: "identical after whitespace normalization",
+			a: hclwrite.Tokens{
+				makeToken(hclsyntax.TokenIdent, "string"),
+				makeToken(hclsyntax.TokenNewline, "\n"),
+			},
+			b: hclwrite.Tokens{
+				makeToken(hclsyntax.TokenIdent, "string"),
+			},
+			want: true,
+		},
+		{
+			name: "different content",
+			a:    hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "string")},
+			b:    hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "number")},
+			want: false,
+		},
+		{
+			name: "different types",
+			a:    hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "foo")},
+			b:    hclwrite.Tokens{makeToken(hclsyntax.TokenOQuote, "foo")},
+			want: false,
+		},
+		{
+			name: "different lengths",
+			a: hclwrite.Tokens{
+				makeToken(hclsyntax.TokenIdent, "a"),
+				makeToken(hclsyntax.TokenIdent, "b"),
+			},
+			b:    hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "a")},
+			want: false,
+		},
+		{
+			name: "both empty",
+			a:    hclwrite.Tokens{},
+			b:    hclwrite.Tokens{},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TokensEqual(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("TokensEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareVariables(t *testing.T) {
+	strTokens := hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "string")}
+	numTokens := hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "number")}
+	boolTokens := hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "bool")}
+
+	tests := []struct {
+		name         string
+		onDisk       map[string]hclwrite.Tokens
+		baseline     map[string]hclwrite.Tokens
+		newGenerated map[string]hclwrite.Tokens
+		want         map[string]CompareResult
+	}{
+		{
+			name:         "identical variable",
+			onDisk:       map[string]hclwrite.Tokens{"name": strTokens},
+			baseline:     map[string]hclwrite.Tokens{"name": strTokens},
+			newGenerated: map[string]hclwrite.Tokens{"name": strTokens},
+			want:         map[string]CompareResult{"name": CompareIdentical},
+		},
+		{
+			name:         "user modified variable",
+			onDisk:       map[string]hclwrite.Tokens{"name": numTokens},
+			baseline:     map[string]hclwrite.Tokens{"name": strTokens},
+			newGenerated: map[string]hclwrite.Tokens{"name": strTokens},
+			want:         map[string]CompareResult{"name": CompareModified},
+		},
+		{
+			name:         "new variable in new spec",
+			onDisk:       map[string]hclwrite.Tokens{},
+			baseline:     map[string]hclwrite.Tokens{},
+			newGenerated: map[string]hclwrite.Tokens{"tags": strTokens},
+			want:         map[string]CompareResult{"tags": CompareNew},
+		},
+		{
+			name:         "removed variable from new spec",
+			onDisk:       map[string]hclwrite.Tokens{"old_field": strTokens},
+			baseline:     map[string]hclwrite.Tokens{"old_field": strTokens},
+			newGenerated: map[string]hclwrite.Tokens{},
+			want:         map[string]CompareResult{"old_field": CompareRemoved},
+		},
+		{
+			name:         "user deleted variable from disk",
+			onDisk:       map[string]hclwrite.Tokens{},
+			baseline:     map[string]hclwrite.Tokens{"name": strTokens},
+			newGenerated: map[string]hclwrite.Tokens{"name": strTokens},
+			want:         map[string]CompareResult{"name": CompareModified},
+		},
+		{
+			name: "mixed scenario",
+			onDisk: map[string]hclwrite.Tokens{
+				"unchanged": strTokens,
+				"modified":  numTokens,
+				"removed":   boolTokens,
+			},
+			baseline: map[string]hclwrite.Tokens{
+				"unchanged": strTokens,
+				"modified":  strTokens,
+				"removed":   boolTokens,
+			},
+			newGenerated: map[string]hclwrite.Tokens{
+				"unchanged": strTokens,
+				"modified":  strTokens,
+				"added":     numTokens,
+			},
+			want: map[string]CompareResult{
+				"unchanged": CompareIdentical,
+				"modified":  CompareModified,
+				"added":     CompareNew,
+				"removed":   CompareRemoved,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CompareVariables(tt.onDisk, tt.baseline, tt.newGenerated)
+			if len(got) != len(tt.want) {
+				t.Fatalf("CompareVariables() returned %d results, want %d", len(got), len(tt.want))
+			}
+			for name, wantResult := range tt.want {
+				gotResult, ok := got[name]
+				if !ok {
+					t.Errorf("CompareVariables() missing result for %q", name)
+					continue
+				}
+				if gotResult != wantResult {
+					t.Errorf("CompareVariables()[%q] = %d, want %d", name, gotResult, wantResult)
+				}
+			}
+		})
+	}
+}
+
+func TestCompareLocals(t *testing.T) {
+	// CompareLocals delegates to CompareVariables, so just verify it works.
+	tokA := hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "expr_a")}
+	tokB := hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "expr_b")}
+
+	onDisk := map[string]hclwrite.Tokens{"body": tokA}
+	baseline := map[string]hclwrite.Tokens{"body": tokA}
+	newGen := map[string]hclwrite.Tokens{"body": tokB}
+
+	got := CompareLocals(onDisk, baseline, newGen)
+	if got["body"] != CompareIdentical {
+		t.Errorf("CompareLocals()[body] = %d, want %d (CompareIdentical)", got["body"], CompareIdentical)
+	}
+}

--- a/terraform/generate_locals.go
+++ b/terraform/generate_locals.go
@@ -14,9 +14,9 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func generateLocals(schema *openapi3.Schema, localName string, supportsIdentity bool, secrets []secretField, resourceType string, caps openapi.InterfaceCapabilities, moduleNamePrefix string, outputDir string) error {
+func buildLocals(schema *openapi3.Schema, localName string, supportsIdentity bool, secrets []secretField, resourceType string, caps openapi.InterfaceCapabilities, moduleNamePrefix string) (*hclwrite.File, error) {
 	if schema == nil {
-		return nil
+		return nil, nil
 	}
 
 	file := hclwrite.NewEmptyFile()
@@ -28,7 +28,7 @@ func generateLocals(schema *openapi3.Schema, localName string, supportsIdentity 
 	secretPaths := newSecretPathSet(secrets)
 	valueExpression, err := constructValue(schema, hclwrite.TokensForIdentifier("var"), true, secretPaths, "", supportsIdentity, moduleNamePrefix)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	localBody.SetAttributeRaw(localName, valueExpression)
 
@@ -43,6 +43,17 @@ func generateLocals(schema *openapi3.Schema, localName string, supportsIdentity 
 		localBody.SetAttributeRaw("private_endpoints", tokensForPrivateEndpointsLocal(resourceType))
 	}
 
+	return file, nil
+}
+
+func generateLocals(schema *openapi3.Schema, localName string, supportsIdentity bool, secrets []secretField, resourceType string, caps openapi.InterfaceCapabilities, moduleNamePrefix string, outputDir string) error {
+	file, err := buildLocals(schema, localName, supportsIdentity, secrets, resourceType, caps, moduleNamePrefix)
+	if err != nil {
+		return err
+	}
+	if file == nil {
+		return nil
+	}
 	return hclgen.WriteFileToDir(outputDir, "locals.tf", file)
 }
 

--- a/terraform/generate_main.go
+++ b/terraform/generate_main.go
@@ -22,7 +22,7 @@ func cleanTypeString(typeStr string) string {
 	return strings.Join(cleaned, "/")
 }
 
-func generateMain(schema *openapi3.Schema, resourceType, apiVersion, localName string, supportsTags, supportsLocation, supportsIdentity, hasSchema bool, secrets []secretField, outputDir string) error {
+func buildMain(schema *openapi3.Schema, resourceType, apiVersion, localName string, supportsTags, supportsLocation, supportsIdentity, hasSchema bool, secrets []secretField) *hclwrite.File {
 	file := hclwrite.NewEmptyFile()
 	body := file.Body()
 
@@ -86,5 +86,9 @@ func generateMain(schema *openapi3.Schema, resourceType, apiVersion, localName s
 	exportPaths := extractComputedPaths(schema)
 	resourceBody.SetAttributeRaw("response_export_values", hclgen.TokensForMultilineStringList(exportPaths))
 
-	return hclgen.WriteFileToDir(outputDir, "main.tf", file)
+	return file
+}
+
+func generateMain(schema *openapi3.Schema, resourceType, apiVersion, localName string, supportsTags, supportsLocation, supportsIdentity, hasSchema bool, secrets []secretField, outputDir string) error {
+	return hclgen.WriteFileToDir(outputDir, "main.tf", buildMain(schema, resourceType, apiVersion, localName, supportsTags, supportsLocation, supportsIdentity, hasSchema, secrets))
 }

--- a/terraform/generate_main.go
+++ b/terraform/generate_main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/matt-FFFFFF/tfmodmake/hclgen"
+	"github.com/matt-FFFFFF/tfmodmake/naming"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -49,9 +50,21 @@ func buildMain(schema *openapi3.Schema, resourceType, apiVersion, localName stri
 
 	// Add sensitive_body if there are secrets
 	if len(secrets) > 0 {
+		// Null-check intermediate containers in sensitive_body that correspond
+		// to flattened property variables. Without this, AzAPI schema validation
+		// rejects partial objects that are missing required non-secret siblings
+		// (e.g., servicePrincipalProfile.clientId when only .secret is present).
+		sensitiveNullCheck := func(pathSegments []string) hclwrite.Tokens {
+			if len(pathSegments) != 2 || pathSegments[0] != "properties" {
+				return nil
+			}
+			varName := naming.ToSnakeCase(pathSegments[1])
+			return hclgen.TokensForTraversal("var", varName)
+		}
+
 		sensitiveBodyTokens := tokensForSensitiveBody(secrets, func(secret secretField) hclwrite.Tokens {
 			return hclgen.TokensForTraversal("var", secret.varName)
-		})
+		}, sensitiveNullCheck)
 		resourceBody.SetAttributeRaw("sensitive_body", sensitiveBodyTokens)
 
 		// Add sensitive_body_version map

--- a/terraform/generate_outputs.go
+++ b/terraform/generate_outputs.go
@@ -14,7 +14,7 @@ import (
 // generateOutputs creates the outputs.tf file with AVM-compliant outputs.
 // Always includes the mandatory AVM outputs: resource_id and name.
 // Also includes outputs for computed/readOnly exported attributes when schema is available.
-func generateOutputs(schema *openapi3.Schema, outputDir string) error {
+func buildOutputs(schema *openapi3.Schema) *hclwrite.File {
 	file := hclwrite.NewEmptyFile()
 	body := file.Body()
 
@@ -69,7 +69,11 @@ func generateOutputs(schema *openapi3.Schema, outputDir string) error {
 		}
 	}
 
-	return hclgen.WriteFileToDir(outputDir, "outputs.tf", file)
+	return file
+}
+
+func generateOutputs(schema *openapi3.Schema, outputDir string) error {
+	return hclgen.WriteFileToDir(outputDir, "outputs.tf", buildOutputs(schema))
 }
 
 func schemaForExportPath(schema *openapi3.Schema, exportPath string) *openapi3.Schema {

--- a/terraform/generate_terraform.go
+++ b/terraform/generate_terraform.go
@@ -6,7 +6,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func generateTerraform(outputDir string) error {
+func buildTerraform() *hclwrite.File {
 	file := hclwrite.NewEmptyFile()
 	body := file.Body()
 
@@ -20,5 +20,9 @@ func generateTerraform(outputDir string) error {
 		"version": cty.StringVal("~> 2.7"),
 	}))
 
-	return hclgen.WriteFileToDir(outputDir, "terraform.tf", file)
+	return file
+}
+
+func generateTerraform(outputDir string) error {
+	return hclgen.WriteFileToDir(outputDir, "terraform.tf", buildTerraform())
 }

--- a/terraform/generate_variables.go
+++ b/terraform/generate_variables.go
@@ -15,7 +15,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, supportsIdentity bool, secrets []secretField, nameSchema *openapi3.Schema, caps openapi.InterfaceCapabilities, moduleNamePrefix string, outputDir string) error {
+func buildVariables(schema *openapi3.Schema, supportsTags, supportsLocation, supportsIdentity bool, secrets []secretField, nameSchema *openapi3.Schema, caps openapi.InterfaceCapabilities, moduleNamePrefix string) (*hclwrite.File, error) {
 	file := hclwrite.NewEmptyFile()
 	body := file.Body()
 
@@ -240,11 +240,11 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 		var err error
 		effectiveProps, err = openapi.GetEffectiveProperties(schema)
 		if err != nil {
-			return fmt.Errorf("getting effective properties: %w", err)
+			return nil, fmt.Errorf("getting effective properties: %w", err)
 		}
 		effectiveRequired, err = openapi.GetEffectiveRequired(schema)
 		if err != nil {
-			return fmt.Errorf("getting effective required: %w", err)
+			return nil, fmt.Errorf("getting effective required: %w", err)
 		}
 
 		for k := range effectiveProps {
@@ -280,11 +280,11 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 
 			childProps, err := openapi.GetEffectiveProperties(propsSchema)
 			if err != nil {
-				return fmt.Errorf("getting effective properties for root properties bag: %w", err)
+				return nil, fmt.Errorf("getting effective properties for root properties bag: %w", err)
 			}
 			childRequired, err := openapi.GetEffectiveRequired(propsSchema)
 			if err != nil {
-				return fmt.Errorf("getting effective required for root properties bag: %w", err)
+				return nil, fmt.Errorf("getting effective required for root properties bag: %w", err)
 			}
 			if len(childProps) == 0 {
 				continue
@@ -308,7 +308,7 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 
 				tfName := naming.ToSnakeCase(childName)
 				if tfName == "" {
-					return fmt.Errorf("could not derive terraform variable name for %s", childName)
+					return nil, fmt.Errorf("could not derive terraform variable name for %s", childName)
 				}
 				// Rename variables that conflict with Terraform module meta-arguments
 				if moduleNamePrefix != "" && tfName == "version" {
@@ -318,15 +318,15 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 				// A collision under flattened root properties is a hard error: users would have no way
 				// to configure that field.
 				if _, reserved := reservedNames[tfName]; reserved {
-					return fmt.Errorf("terraform variable name collision: %q (from properties.%s)", tfName, childName)
+					return nil, fmt.Errorf("terraform variable name collision: %q (from properties.%s)", tfName, childName)
 				}
 				if _, exists := seenNames[tfName]; exists {
-					return fmt.Errorf("terraform variable name collision: %q (from properties.%s)", tfName, childName)
+					return nil, fmt.Errorf("terraform variable name collision: %q (from properties.%s)", tfName, childName)
 				}
 				seenNames[tfName] = struct{}{}
 
 				if _, err := appendSchemaVariable(tfName, childName, childSchema, childRequired); err != nil {
-					return err
+					return nil, err
 				}
 
 				body.AppendNewline()
@@ -341,7 +341,7 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 
 		tfName := naming.ToSnakeCase(name)
 		if tfName == "" {
-			return fmt.Errorf("could not derive terraform variable name for %s", name)
+			return nil, fmt.Errorf("could not derive terraform variable name for %s", name)
 		}
 		if _, reserved := reservedNames[tfName]; reserved {
 			continue
@@ -351,11 +351,11 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 			tfName = moduleNamePrefix + "_version"
 		}
 		if _, exists := seenNames[tfName]; exists {
-			return fmt.Errorf("terraform variable name collision: %q (from %s)", tfName, name)
+			return nil, fmt.Errorf("terraform variable name collision: %q (from %s)", tfName, name)
 		}
 		seenNames[tfName] = struct{}{}
 		if _, err := appendSchemaVariable(tfName, name, propSchema, effectiveRequired); err != nil {
-			return err
+			return nil, err
 		}
 
 		if i < len(keys)-1 {
@@ -378,7 +378,7 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 
 		tfType, err := mapType(secret.schema)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		secretVarBody := appendVariable(
 			secret.varName,
@@ -400,7 +400,7 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 		}
 		versionVarName := secret.varName + "_version"
 		if _, exists := seenNames[versionVarName]; exists {
-			return fmt.Errorf("terraform variable name collision: %q (from secret version var)", versionVarName)
+			return nil, fmt.Errorf("terraform variable name collision: %q (from secret version var)", versionVarName)
 		}
 		versionBody := appendVariable(
 			versionVarName,
@@ -466,6 +466,14 @@ func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, 
 	// private_endpoints (only if swagger indicates Private Link/Private Endpoint support)
 	emitPrivateEndpointsVars(body, caps, appendVariable)
 
+	return file, nil
+}
+
+func generateVariables(schema *openapi3.Schema, supportsTags, supportsLocation, supportsIdentity bool, secrets []secretField, nameSchema *openapi3.Schema, caps openapi.InterfaceCapabilities, moduleNamePrefix string, outputDir string) error {
+	file, err := buildVariables(schema, supportsTags, supportsLocation, supportsIdentity, secrets, nameSchema, caps, moduleNamePrefix)
+	if err != nil {
+		return err
+	}
 	return hclgen.WriteFileToDir(outputDir, "variables.tf", file)
 }
 

--- a/terraform/generator.go
+++ b/terraform/generator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/matt-FFFFFF/tfmodmake/openapi"
 )
 
@@ -179,4 +180,69 @@ func SupportsTags(schema *openapi3.Schema) bool {
 // SupportsLocation reports whether the schema includes a writable "location" property, following allOf inheritance.
 func SupportsLocation(schema *openapi3.Schema) bool {
 	return hasWritableProperty(schema, "location")
+}
+
+// GeneratedModule holds all generated HCL files in memory, enabling comparison
+// without writing to disk.
+type GeneratedModule struct {
+	Terraform *hclwrite.File
+	Variables *hclwrite.File
+	Locals    *hclwrite.File
+	Main      *hclwrite.File
+	Outputs   *hclwrite.File
+}
+
+// GenerateInMemory runs the generation pipeline and returns all files in memory
+// without writing to disk. This is used by the update command to produce baseline
+// and new-version outputs for comparison.
+func GenerateInMemory(resourceType string, opts ...GeneratorOption) (*GeneratedModule, error) {
+	o := &generatorOptions{
+		resourceType: resourceType,
+		outputDir:    ".",
+		localName:    "resource_body",
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	hasSchema := o.schema != nil
+	supportsIdentity := SupportsIdentity(o.schema)
+
+	var caps openapi.InterfaceCapabilities
+	var nameSchema *openapi3.Schema
+	if o.spec != nil {
+		caps = openapi.DetectInterfaceCapabilities(o.spec, o.resourceType)
+		nameSchema, _ = openapi.FindResourceNameSchema(o.spec, o.resourceType)
+	}
+
+	var secrets []secretField
+	if hasSchema {
+		var err error
+		secrets, err = collectSecretFields(o.schema, "")
+		if err != nil {
+			return nil, fmt.Errorf("collecting secret fields: %w", err)
+		}
+	}
+
+	mod := &GeneratedModule{
+		Terraform: buildTerraform(),
+		Outputs:   buildOutputs(o.schema),
+	}
+
+	var err error
+	mod.Variables, err = buildVariables(o.schema, o.supportsTags, o.supportsLocation, supportsIdentity, secrets, nameSchema, caps, o.moduleNamePrefix)
+	if err != nil {
+		return nil, fmt.Errorf("building variables: %w", err)
+	}
+
+	if hasSchema {
+		mod.Locals, err = buildLocals(o.schema, o.localName, supportsIdentity, secrets, o.resourceType, caps, o.moduleNamePrefix)
+		if err != nil {
+			return nil, fmt.Errorf("building locals: %w", err)
+		}
+	}
+
+	mod.Main = buildMain(o.schema, o.resourceType, o.apiVersion, o.localName, o.supportsTags, o.supportsLocation, supportsIdentity, hasSchema, secrets)
+
+	return mod, nil
 }

--- a/terraform/hcl_edit.go
+++ b/terraform/hcl_edit.go
@@ -1,0 +1,151 @@
+package terraform
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// UpdateVariableType replaces the type attribute of a variable block in a parsed HCL file.
+func UpdateVariableType(file *hclwrite.File, varName string, newType hclwrite.Tokens) error {
+	for _, block := range file.Body().Blocks() {
+		if block.Type() != "variable" {
+			continue
+		}
+		labels := block.Labels()
+		if len(labels) == 0 || labels[0] != varName {
+			continue
+		}
+		block.Body().SetAttributeRaw("type", newType)
+		return nil
+	}
+	return fmt.Errorf("variable %q not found", varName)
+}
+
+// AddVariableBlock appends a complete variable block (from a generated file) to the target file.
+// It extracts the variable block for varName from sourceFile and appends it to targetFile.
+func AddVariableBlock(targetFile, sourceFile *hclwrite.File, varName string) error {
+	for _, block := range sourceFile.Body().Blocks() {
+		if block.Type() != "variable" {
+			continue
+		}
+		labels := block.Labels()
+		if len(labels) == 0 || labels[0] != varName {
+			continue
+		}
+		targetFile.Body().AppendNewline()
+		targetFile.Body().AppendUnstructuredTokens(block.BuildTokens(nil))
+		return nil
+	}
+	return fmt.Errorf("variable %q not found in source file", varName)
+}
+
+// RemoveVariableBlock removes a variable block by name from a parsed HCL file.
+func RemoveVariableBlock(file *hclwrite.File, varName string) error {
+	for _, block := range file.Body().Blocks() {
+		if block.Type() != "variable" {
+			continue
+		}
+		labels := block.Labels()
+		if len(labels) == 0 || labels[0] != varName {
+			continue
+		}
+		file.Body().RemoveBlock(block)
+		return nil
+	}
+	return fmt.Errorf("variable %q not found", varName)
+}
+
+// UpdateLocalAttribute replaces an attribute expression in the first locals block.
+func UpdateLocalAttribute(file *hclwrite.File, attrName string, newExpr hclwrite.Tokens) error {
+	for _, block := range file.Body().Blocks() {
+		if block.Type() != "locals" {
+			continue
+		}
+		if block.Body().GetAttribute(attrName) == nil {
+			continue
+		}
+		block.Body().SetAttributeRaw(attrName, newExpr)
+		return nil
+	}
+	return fmt.Errorf("local attribute %q not found", attrName)
+}
+
+// AddLocalAttribute adds a new attribute to the first locals block.
+func AddLocalAttribute(file *hclwrite.File, attrName string, expr hclwrite.Tokens) error {
+	for _, block := range file.Body().Blocks() {
+		if block.Type() != "locals" {
+			continue
+		}
+		block.Body().SetAttributeRaw(attrName, expr)
+		return nil
+	}
+	return fmt.Errorf("no locals block found")
+}
+
+// RemoveLocalAttribute removes an attribute from the first locals block that contains it.
+func RemoveLocalAttribute(file *hclwrite.File, attrName string) error {
+	for _, block := range file.Body().Blocks() {
+		if block.Type() != "locals" {
+			continue
+		}
+		if block.Body().GetAttribute(attrName) == nil {
+			continue
+		}
+		block.Body().RemoveAttribute(attrName)
+		return nil
+	}
+	return fmt.Errorf("local attribute %q not found", attrName)
+}
+
+// UpdateResourceTypeAttribute updates the type string in azapi_resource "this"
+// from "ResourceType@OldVersion" to "ResourceType@NewVersion".
+func UpdateResourceTypeAttribute(file *hclwrite.File, newTypeString string) error {
+	for _, block := range file.Body().Blocks() {
+		if block.Type() != "resource" {
+			continue
+		}
+		labels := block.Labels()
+		if len(labels) < 2 || labels[0] != "azapi_resource" || labels[1] != "this" {
+			continue
+		}
+		block.Body().SetAttributeValue("type", cty.StringVal(newTypeString))
+		return nil
+	}
+	return fmt.Errorf("no azapi_resource \"this\" block found")
+}
+
+// UpdateResponseExportValues replaces the response_export_values attribute
+// in azapi_resource "this" with the new set of computed paths.
+func UpdateResponseExportValues(file *hclwrite.File, paths []string) error {
+	for _, block := range file.Body().Blocks() {
+		if block.Type() != "resource" {
+			continue
+		}
+		labels := block.Labels()
+		if len(labels) < 2 || labels[0] != "azapi_resource" || labels[1] != "this" {
+			continue
+		}
+		if len(paths) == 0 {
+			block.Body().RemoveAttribute("response_export_values")
+			return nil
+		}
+		block.Body().SetAttributeRaw("response_export_values", tokensForStringList(paths))
+		return nil
+	}
+	return fmt.Errorf("no azapi_resource \"this\" block found")
+}
+
+// tokensForStringList creates HCL tokens for a list of string literals: ["a", "b", "c"]
+func tokensForStringList(values []string) hclwrite.Tokens {
+	// Build a quoted list expression via cty values for correctness.
+	var items []string
+	for _, v := range values {
+		items = append(items, fmt.Sprintf("%q", v))
+	}
+	raw := "[" + strings.Join(items, ", ") + "]"
+	// Parse the expression to get proper tokens.
+	return hclwrite.TokensForIdentifier(raw)
+}

--- a/terraform/hcl_edit.go
+++ b/terraform/hcl_edit.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
@@ -140,12 +139,9 @@ func UpdateResponseExportValues(file *hclwrite.File, paths []string) error {
 
 // tokensForStringList creates HCL tokens for a list of string literals: ["a", "b", "c"]
 func tokensForStringList(values []string) hclwrite.Tokens {
-	// Build a quoted list expression via cty values for correctness.
-	var items []string
-	for _, v := range values {
-		items = append(items, fmt.Sprintf("%q", v))
+	ctyVals := make([]cty.Value, len(values))
+	for i, v := range values {
+		ctyVals[i] = cty.StringVal(v)
 	}
-	raw := "[" + strings.Join(items, ", ") + "]"
-	// Parse the expression to get proper tokens.
-	return hclwrite.TokensForIdentifier(raw)
+	return hclwrite.TokensForValue(cty.ListVal(ctyVals))
 }

--- a/terraform/hcl_edit_test.go
+++ b/terraform/hcl_edit_test.go
@@ -1,0 +1,321 @@
+package terraform
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+func parseHCL(t *testing.T, src string) *hclwrite.File {
+	t.Helper()
+	file, diags := hclwrite.ParseConfig([]byte(src), "test.tf", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("failed to parse HCL: %s", diags.Error())
+	}
+	return file
+}
+
+func TestUpdateVariableType(t *testing.T) {
+	src := `variable "name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+`
+	file := parseHCL(t, src)
+	newType := hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "number")}
+
+	if err := UpdateVariableType(file, "name", newType); err != nil {
+		t.Fatalf("UpdateVariableType() error: %v", err)
+	}
+
+	output := string(file.Bytes())
+	if !strings.Contains(output, "number") {
+		t.Errorf("expected output to contain 'number', got:\n%s", output)
+	}
+	// location should be unchanged
+	if !strings.Contains(output, `variable "location"`) {
+		t.Error("expected 'location' variable to remain")
+	}
+}
+
+func TestUpdateVariableType_notFound(t *testing.T) {
+	src := `variable "name" {
+  type = string
+}
+`
+	file := parseHCL(t, src)
+	newType := hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "number")}
+
+	err := UpdateVariableType(file, "nonexistent", newType)
+	if err == nil {
+		t.Fatal("expected error for missing variable, got nil")
+	}
+}
+
+func TestAddVariableBlock(t *testing.T) {
+	targetSrc := `variable "name" {
+  type = string
+}
+`
+	sourceSrc := `variable "location" {
+  type    = string
+  default = null
+}
+`
+	targetFile := parseHCL(t, targetSrc)
+	sourceFile := parseHCL(t, sourceSrc)
+
+	if err := AddVariableBlock(targetFile, sourceFile, "location"); err != nil {
+		t.Fatalf("AddVariableBlock() error: %v", err)
+	}
+
+	output := string(targetFile.Bytes())
+	if !strings.Contains(output, `variable "location"`) {
+		t.Errorf("expected output to contain 'location' variable, got:\n%s", output)
+	}
+	if !strings.Contains(output, `variable "name"`) {
+		t.Error("expected original 'name' variable to remain")
+	}
+}
+
+func TestAddVariableBlock_notFoundInSource(t *testing.T) {
+	targetFile := parseHCL(t, `variable "name" { type = string }`)
+	sourceFile := parseHCL(t, `variable "other" { type = string }`)
+
+	err := AddVariableBlock(targetFile, sourceFile, "missing")
+	if err == nil {
+		t.Fatal("expected error for missing variable in source, got nil")
+	}
+}
+
+func TestRemoveVariableBlock(t *testing.T) {
+	src := `variable "name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+`
+	file := parseHCL(t, src)
+
+	if err := RemoveVariableBlock(file, "name"); err != nil {
+		t.Fatalf("RemoveVariableBlock() error: %v", err)
+	}
+
+	output := string(file.Bytes())
+	if strings.Contains(output, `variable "name"`) {
+		t.Errorf("expected 'name' variable to be removed, got:\n%s", output)
+	}
+	if !strings.Contains(output, `variable "location"`) {
+		t.Error("expected 'location' variable to remain")
+	}
+}
+
+func TestRemoveVariableBlock_notFound(t *testing.T) {
+	file := parseHCL(t, `variable "name" { type = string }`)
+
+	err := RemoveVariableBlock(file, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing variable, got nil")
+	}
+}
+
+func TestUpdateLocalAttribute(t *testing.T) {
+	src := `locals {
+  resource_body = {
+    properties = {
+      foo = var.foo
+    }
+  }
+  other = "keep"
+}
+`
+	file := parseHCL(t, src)
+	newExpr := hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, `{ updated = true }`)}
+
+	if err := UpdateLocalAttribute(file, "resource_body", newExpr); err != nil {
+		t.Fatalf("UpdateLocalAttribute() error: %v", err)
+	}
+
+	output := string(file.Bytes())
+	if !strings.Contains(output, "updated") {
+		t.Errorf("expected output to contain 'updated', got:\n%s", output)
+	}
+	if !strings.Contains(output, "other") {
+		t.Error("expected 'other' local to remain")
+	}
+}
+
+func TestUpdateLocalAttribute_notFound(t *testing.T) {
+	src := `locals {
+  foo = "bar"
+}
+`
+	file := parseHCL(t, src)
+	newExpr := hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "true")}
+
+	err := UpdateLocalAttribute(file, "nonexistent", newExpr)
+	if err == nil {
+		t.Fatal("expected error for missing local attribute, got nil")
+	}
+}
+
+func TestAddLocalAttribute(t *testing.T) {
+	src := `locals {
+  existing = "value"
+}
+`
+	file := parseHCL(t, src)
+	newExpr := hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, `"new_value"`)}
+
+	if err := AddLocalAttribute(file, "new_attr", newExpr); err != nil {
+		t.Fatalf("AddLocalAttribute() error: %v", err)
+	}
+
+	output := string(file.Bytes())
+	if !strings.Contains(output, "new_attr") {
+		t.Errorf("expected output to contain 'new_attr', got:\n%s", output)
+	}
+	if !strings.Contains(output, "existing") {
+		t.Error("expected 'existing' local to remain")
+	}
+}
+
+func TestAddLocalAttribute_noLocalsBlock(t *testing.T) {
+	src := `variable "name" {
+  type = string
+}
+`
+	file := parseHCL(t, src)
+	expr := hclwrite.Tokens{makeToken(hclsyntax.TokenIdent, "true")}
+
+	err := AddLocalAttribute(file, "foo", expr)
+	if err == nil {
+		t.Fatal("expected error when no locals block exists, got nil")
+	}
+}
+
+func TestRemoveLocalAttribute(t *testing.T) {
+	src := `locals {
+  keep_me  = "yes"
+  remove_me = "no"
+}
+`
+	file := parseHCL(t, src)
+
+	if err := RemoveLocalAttribute(file, "remove_me"); err != nil {
+		t.Fatalf("RemoveLocalAttribute() error: %v", err)
+	}
+
+	output := string(file.Bytes())
+	if strings.Contains(output, "remove_me") {
+		t.Errorf("expected 'remove_me' to be removed, got:\n%s", output)
+	}
+	if !strings.Contains(output, "keep_me") {
+		t.Error("expected 'keep_me' to remain")
+	}
+}
+
+func TestRemoveLocalAttribute_notFound(t *testing.T) {
+	src := `locals {
+  foo = "bar"
+}
+`
+	file := parseHCL(t, src)
+
+	err := RemoveLocalAttribute(file, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing local attribute, got nil")
+	}
+}
+
+func TestUpdateResourceTypeAttribute(t *testing.T) {
+	src := `resource "azapi_resource" "this" {
+  type = "Microsoft.App/managedEnvironments@2024-01-01"
+  name = var.name
+}
+`
+	file := parseHCL(t, src)
+
+	if err := UpdateResourceTypeAttribute(file, "Microsoft.App/managedEnvironments@2025-10-02-preview"); err != nil {
+		t.Fatalf("UpdateResourceTypeAttribute() error: %v", err)
+	}
+
+	output := string(file.Bytes())
+	if !strings.Contains(output, "2025-10-02-preview") {
+		t.Errorf("expected output to contain new version, got:\n%s", output)
+	}
+	if strings.Contains(output, "2024-01-01") {
+		t.Error("expected old version to be replaced")
+	}
+}
+
+func TestUpdateResourceTypeAttribute_notFound(t *testing.T) {
+	src := `resource "azapi_resource" "other" {
+  type = "Microsoft.App/managedEnvironments@2024-01-01"
+}
+`
+	file := parseHCL(t, src)
+
+	err := UpdateResourceTypeAttribute(file, "Microsoft.App/managedEnvironments@2025-10-02-preview")
+	if err == nil {
+		t.Fatal("expected error when no azapi_resource 'this' block exists, got nil")
+	}
+}
+
+func TestUpdateResponseExportValues(t *testing.T) {
+	src := `resource "azapi_resource" "this" {
+  type                   = "Microsoft.App/managedEnvironments@2024-01-01"
+  response_export_values = ["properties.provisioningState"]
+}
+`
+	file := parseHCL(t, src)
+
+	newPaths := []string{"properties.provisioningState", "properties.defaultDomain"}
+	if err := UpdateResponseExportValues(file, newPaths); err != nil {
+		t.Fatalf("UpdateResponseExportValues() error: %v", err)
+	}
+
+	output := string(file.Bytes())
+	if !strings.Contains(output, "defaultDomain") {
+		t.Errorf("expected output to contain 'defaultDomain', got:\n%s", output)
+	}
+}
+
+func TestUpdateResponseExportValues_emptyPaths(t *testing.T) {
+	src := `resource "azapi_resource" "this" {
+  type                   = "Microsoft.App/managedEnvironments@2024-01-01"
+  response_export_values = ["properties.provisioningState"]
+}
+`
+	file := parseHCL(t, src)
+
+	if err := UpdateResponseExportValues(file, nil); err != nil {
+		t.Fatalf("UpdateResponseExportValues() error: %v", err)
+	}
+
+	output := string(file.Bytes())
+	if strings.Contains(output, "response_export_values") {
+		t.Errorf("expected response_export_values to be removed, got:\n%s", output)
+	}
+}
+
+func TestUpdateResponseExportValues_notFound(t *testing.T) {
+	src := `resource "azapi_resource" "other" {
+  type = "Microsoft.App/managedEnvironments@2024-01-01"
+}
+`
+	file := parseHCL(t, src)
+
+	err := UpdateResponseExportValues(file, []string{"foo"})
+	if err == nil {
+		t.Fatal("expected error when no azapi_resource 'this' block exists, got nil")
+	}
+}

--- a/terraform/parse_existing.go
+++ b/terraform/parse_existing.go
@@ -1,0 +1,158 @@
+package terraform
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// ParseHCLFile reads and parses an HCL file from disk using hclwrite.
+func ParseHCLFile(path string) (*hclwrite.File, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	file, diags := hclwrite.ParseConfig(data, path, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("parsing %s: %s", path, diags.Error())
+	}
+	return file, nil
+}
+
+// ParseModuleFile is a convenience wrapper that parses a named HCL file inside a module directory.
+func ParseModuleFile(moduleDir, filename string) (*hclwrite.File, error) {
+	return ParseHCLFile(filepath.Join(moduleDir, filename))
+}
+
+// ExtractResourceTypeAndVersion parses a main.tf hclwrite.File and returns the
+// resource type and API version from the azapi_resource "this" type attribute.
+//
+// Input type value: "Microsoft.App/managedEnvironments@2025-10-02-preview"
+// Returns: ("Microsoft.App/managedEnvironments", "2025-10-02-preview", nil)
+func ExtractResourceTypeAndVersion(mainFile *hclwrite.File) (string, string, error) {
+	if mainFile == nil {
+		return "", "", fmt.Errorf("main file is nil")
+	}
+
+	for _, block := range mainFile.Body().Blocks() {
+		if block.Type() != "resource" {
+			continue
+		}
+		labels := block.Labels()
+		if len(labels) < 2 || labels[0] != "azapi_resource" || labels[1] != "this" {
+			continue
+		}
+		typeAttr := block.Body().GetAttribute("type")
+		if typeAttr == nil {
+			return "", "", fmt.Errorf("azapi_resource \"this\" has no type attribute")
+		}
+		typeVal := extractQuotedStringFromTokens(typeAttr.Expr().BuildTokens(nil))
+		if typeVal == "" {
+			return "", "", fmt.Errorf("could not extract type string from azapi_resource \"this\"")
+		}
+		return splitTypeAndVersion(typeVal)
+	}
+
+	return "", "", fmt.Errorf("no azapi_resource \"this\" block found in main.tf")
+}
+
+// splitTypeAndVersion splits "Microsoft.App/managedEnvironments@2025-10-02-preview"
+// into ("Microsoft.App/managedEnvironments", "2025-10-02-preview").
+func splitTypeAndVersion(typeStr string) (string, string, error) {
+	idx := strings.LastIndex(typeStr, "@")
+	if idx < 0 {
+		return "", "", fmt.Errorf("type string %q does not contain @apiVersion", typeStr)
+	}
+	resourceType := typeStr[:idx]
+	apiVersion := typeStr[idx+1:]
+	if resourceType == "" || apiVersion == "" {
+		return "", "", fmt.Errorf("invalid type string %q: empty resource type or API version", typeStr)
+	}
+	return resourceType, apiVersion, nil
+}
+
+// extractQuotedStringFromTokens extracts the first quoted string literal value
+// from a sequence of HCL tokens.
+func extractQuotedStringFromTokens(tokens hclwrite.Tokens) string {
+	var parts []string
+	inQuote := false
+	for _, tok := range tokens {
+		switch {
+		case tok.Type == hclsyntax.TokenOQuote:
+			inQuote = true
+		case tok.Type == hclsyntax.TokenCQuote:
+			inQuote = false
+		case inQuote:
+			parts = append(parts, string(tok.Bytes))
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// ExtractVariableTypes returns a map of variable name to type expression tokens
+// from a parsed variables.tf file.
+func ExtractVariableTypes(varsFile *hclwrite.File) map[string]hclwrite.Tokens {
+	if varsFile == nil {
+		return nil
+	}
+	result := make(map[string]hclwrite.Tokens)
+	for _, block := range varsFile.Body().Blocks() {
+		if block.Type() != "variable" {
+			continue
+		}
+		labels := block.Labels()
+		if len(labels) == 0 {
+			continue
+		}
+		varName := labels[0]
+		typeAttr := block.Body().GetAttribute("type")
+		if typeAttr == nil {
+			continue
+		}
+		result[varName] = typeAttr.Expr().BuildTokens(nil)
+	}
+	return result
+}
+
+// ExtractVariableBlocks returns a map of variable name to the full variable block
+// from a parsed variables.tf file.
+func ExtractVariableBlocks(varsFile *hclwrite.File) map[string]*hclwrite.Block {
+	if varsFile == nil {
+		return nil
+	}
+	result := make(map[string]*hclwrite.Block)
+	for _, block := range varsFile.Body().Blocks() {
+		if block.Type() != "variable" {
+			continue
+		}
+		labels := block.Labels()
+		if len(labels) == 0 {
+			continue
+		}
+		result[labels[0]] = block
+	}
+	return result
+}
+
+// ExtractLocalAssignments returns a map of local name to expression tokens
+// from a parsed locals.tf file.
+func ExtractLocalAssignments(localsFile *hclwrite.File) map[string]hclwrite.Tokens {
+	if localsFile == nil {
+		return nil
+	}
+	result := make(map[string]hclwrite.Tokens)
+	for _, block := range localsFile.Body().Blocks() {
+		if block.Type() != "locals" {
+			continue
+		}
+		for name, attr := range block.Body().Attributes() {
+			result[name] = attr.Expr().BuildTokens(nil)
+		}
+	}
+	return result
+}

--- a/terraform/parse_existing_test.go
+++ b/terraform/parse_existing_test.go
@@ -1,0 +1,244 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+func TestExtractResourceTypeAndVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		hcl         string
+		wantType    string
+		wantVersion string
+		wantErr     bool
+	}{
+		{
+			name: "standard resource type",
+			hcl: `resource "azapi_resource" "this" {
+  type = "Microsoft.App/managedEnvironments@2025-10-02-preview"
+  name = var.name
+}`,
+			wantType:    "Microsoft.App/managedEnvironments",
+			wantVersion: "2025-10-02-preview",
+		},
+		{
+			name: "stable version",
+			hcl: `resource "azapi_resource" "this" {
+  type = "Microsoft.ContainerService/managedClusters@2024-02-01"
+  name = var.name
+}`,
+			wantType:    "Microsoft.ContainerService/managedClusters",
+			wantVersion: "2024-02-01",
+		},
+		{
+			name: "no azapi_resource this block",
+			hcl: `resource "azapi_resource" "other" {
+  type = "Microsoft.App/managedEnvironments@2025-10-02-preview"
+}`,
+			wantErr: true,
+		},
+		{
+			name: "no type attribute",
+			hcl: `resource "azapi_resource" "this" {
+  name = var.name
+}`,
+			wantErr: true,
+		},
+		{
+			name:    "nil file",
+			hcl:     "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.hcl == "" && tt.name == "nil file" {
+				_, _, err := ExtractResourceTypeAndVersion(nil)
+				if !tt.wantErr {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+
+			file, diags := hclwrite.ParseConfig([]byte(tt.hcl), "test.tf", hcl.Pos{Line: 1, Column: 1})
+			if diags.HasErrors() {
+				t.Fatalf("failed to parse HCL: %s", diags.Error())
+			}
+
+			gotType, gotVersion, err := ExtractResourceTypeAndVersion(file)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotType != tt.wantType {
+				t.Errorf("resource type: got %q, want %q", gotType, tt.wantType)
+			}
+			if gotVersion != tt.wantVersion {
+				t.Errorf("version: got %q, want %q", gotVersion, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestSplitTypeAndVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantType    string
+		wantVersion string
+		wantErr     bool
+	}{
+		{
+			name:        "standard",
+			input:       "Microsoft.App/managedEnvironments@2025-10-02-preview",
+			wantType:    "Microsoft.App/managedEnvironments",
+			wantVersion: "2025-10-02-preview",
+		},
+		{
+			name:    "no @ symbol",
+			input:   "Microsoft.App/managedEnvironments",
+			wantErr: true,
+		},
+		{
+			name:    "empty type",
+			input:   "@2025-10-02-preview",
+			wantErr: true,
+		},
+		{
+			name:    "empty version",
+			input:   "Microsoft.App/managedEnvironments@",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotVersion, err := splitTypeAndVersion(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotType != tt.wantType {
+				t.Errorf("type: got %q, want %q", gotType, tt.wantType)
+			}
+			if gotVersion != tt.wantVersion {
+				t.Errorf("version: got %q, want %q", gotVersion, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestExtractVariableTypes(t *testing.T) {
+	hclContent := `variable "name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "config" {
+  type = object({
+    foo = string
+    bar = optional(number)
+  })
+}
+`
+	file, diags := hclwrite.ParseConfig([]byte(hclContent), "test.tf", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("failed to parse HCL: %s", diags.Error())
+	}
+
+	result := ExtractVariableTypes(file)
+	if len(result) != 3 {
+		t.Fatalf("expected 3 variables, got %d", len(result))
+	}
+
+	for _, name := range []string{"name", "location", "config"} {
+		if _, ok := result[name]; !ok {
+			t.Errorf("expected variable %q in result", name)
+		}
+	}
+}
+
+func TestExtractVariableTypes_nilFile(t *testing.T) {
+	result := ExtractVariableTypes(nil)
+	if result != nil {
+		t.Errorf("expected nil for nil file, got %v", result)
+	}
+}
+
+func TestExtractLocalAssignments(t *testing.T) {
+	hclContent := `locals {
+  resource_body = {
+    properties = {
+      foo = var.foo
+    }
+  }
+  managed_identities = {}
+}
+`
+	file, diags := hclwrite.ParseConfig([]byte(hclContent), "test.tf", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("failed to parse HCL: %s", diags.Error())
+	}
+
+	result := ExtractLocalAssignments(file)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 local assignments, got %d", len(result))
+	}
+
+	for _, name := range []string{"resource_body", "managed_identities"} {
+		if _, ok := result[name]; !ok {
+			t.Errorf("expected local %q in result", name)
+		}
+	}
+}
+
+func TestExtractLocalAssignments_nilFile(t *testing.T) {
+	result := ExtractLocalAssignments(nil)
+	if result != nil {
+		t.Errorf("expected nil for nil file, got %v", result)
+	}
+}
+
+func TestExtractVariableBlocks(t *testing.T) {
+	hclContent := `variable "name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+  default = null
+}
+`
+	file, diags := hclwrite.ParseConfig([]byte(hclContent), "test.tf", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("failed to parse HCL: %s", diags.Error())
+	}
+
+	result := ExtractVariableBlocks(file)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(result))
+	}
+	if _, ok := result["name"]; !ok {
+		t.Error("expected variable 'name' in result")
+	}
+	if _, ok := result["location"]; !ok {
+		t.Error("expected variable 'location' in result")
+	}
+}

--- a/terraform/secrets.go
+++ b/terraform/secrets.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/matt-FFFFFF/tfmodmake/hclgen"
 	"github.com/matt-FFFFFF/tfmodmake/naming"
 	"github.com/matt-FFFFFF/tfmodmake/openapi"
 )
@@ -229,7 +230,19 @@ func (n *sensitiveBodyNode) ensureChild(key string) *sensitiveBodyNode {
 	return child
 }
 
-func tokensForSensitiveBody(secrets []secretField, valueFor func(secretField) hclwrite.Tokens) hclwrite.Tokens {
+// nullCheckFunc returns HCL tokens for an expression that should be null-checked
+// when rendering a sensitive_body intermediate container at the given path segments.
+// If the container should not be null-checked, it returns nil.
+type nullCheckFunc func(pathSegments []string) hclwrite.Tokens
+
+// tokensForSensitiveBody builds a nested HCL object expression for the sensitive_body
+// attribute, reconstructing the path hierarchy from flat secret field paths.
+//
+// The nullCheckFor callback allows intermediate container objects to be wrapped with
+// null-equality ternaries so that partial objects aren't emitted when the parent
+// variable is null. This prevents AzAPI schema validation errors where a container
+// has required non-secret siblings that are absent from sensitive_body.
+func tokensForSensitiveBody(secrets []secretField, valueFor func(secretField) hclwrite.Tokens, nullCheckFor nullCheckFunc) hclwrite.Tokens {
 	root := &sensitiveBodyNode{}
 	for i := range secrets {
 		path := strings.TrimSpace(secrets[i].path)
@@ -248,8 +261,8 @@ func tokensForSensitiveBody(secrets []secretField, valueFor func(secretField) hc
 		node.secret = &secrets[i]
 	}
 
-	var render func(node *sensitiveBodyNode) hclwrite.Tokens
-	render = func(node *sensitiveBodyNode) hclwrite.Tokens {
+	var render func(node *sensitiveBodyNode, pathSegments []string) hclwrite.Tokens
+	render = func(node *sensitiveBodyNode, pathSegments []string) hclwrite.Tokens {
 		if node == nil || len(node.children) == 0 {
 			return hclwrite.TokensForObject(nil)
 		}
@@ -262,11 +275,21 @@ func tokensForSensitiveBody(secrets []secretField, valueFor func(secretField) hc
 		attrs := make([]hclwrite.ObjectAttrTokens, 0, len(keys))
 		for _, k := range keys {
 			child := node.children[k]
+			childPath := append(pathSegments, k) //nolint:gocritic // intentionally creating new slice per child
 			var value hclwrite.Tokens
 			if child != nil && child.secret != nil && len(child.children) == 0 {
 				value = valueFor(*child.secret)
 			} else {
-				value = render(child)
+				childObj := render(child, childPath)
+				if nullCheckFor != nil {
+					if checkExpr := nullCheckFor(childPath); checkExpr != nil {
+						value = hclgen.NullEqualityTernary(checkExpr, childObj)
+					} else {
+						value = childObj
+					}
+				} else {
+					value = childObj
+				}
 			}
 			attrs = append(attrs, hclwrite.ObjectAttrTokens{
 				Name:  tokensForObjectKey(k),
@@ -276,5 +299,5 @@ func tokensForSensitiveBody(secrets []secretField, valueFor func(secretField) hc
 		return hclwrite.TokensForObject(attrs)
 	}
 
-	return render(root)
+	return render(root, nil)
 }

--- a/terraform/update.go
+++ b/terraform/update.go
@@ -32,6 +32,9 @@ type UpdateSummary struct {
 type UpdateOptions struct {
 	// ModuleDir is the directory containing the existing module.
 	ModuleDir string
+	// OldSpecs is a list of paths or URLs to the old (current) OpenAPI spec files.
+	// Used to generate the baseline for 3-way comparison.
+	OldSpecs []string
 	// NewSpecs is a list of paths or URLs to the new OpenAPI spec files.
 	NewSpecs []string
 	// ResourceType overrides the resource type (if empty, inferred from main.tf).
@@ -43,7 +46,13 @@ type UpdateOptions struct {
 }
 
 // Update upgrades an existing Terraform module to a new API version while preserving
-// user customizations.
+// user customizations. It performs a 3-way comparison:
+//  1. Baseline: generated from old (current) spec
+//  2. On-disk: the user's actual files (may include customizations)
+//  3. New: generated from the new spec
+//
+// Items where on-disk matches baseline are auto-upgraded to new. Items where on-disk
+// differs from baseline are flagged for manual review.
 func Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
 	if opts.ModuleDir == "" {
 		opts.ModuleDir = "."
@@ -52,7 +61,7 @@ func Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
 		opts.LocalName = "resource_body"
 	}
 
-	// Step 1: Read current module state
+	// Step 1: Read current module state from disk.
 	mainFile, err := ParseModuleFile(opts.ModuleDir, "main.tf")
 	if err != nil {
 		return nil, fmt.Errorf("reading main.tf: %w", err)
@@ -82,19 +91,31 @@ func Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
 		onDiskLocalAssignments = ExtractLocalAssignments(localsFile)
 	}
 
-	// Step 2: Generate baseline from current spec (in memory)
-	baselineResult, err := LoadResource(ctx, opts.NewSpecs, resourceType)
+	// Step 2: Generate baseline from old (current) spec for dirty detection.
+	baselineResult, err := LoadResource(ctx, opts.OldSpecs, resourceType)
 	if err != nil {
-		// If we can't load from the new specs with the old version, we might need
-		// the current spec. For now, generate baseline from what we have on disk.
-		// The baseline is used for dirty detection. If we can't produce one, we treat
-		// everything as user-modified (conservative).
-		return nil, fmt.Errorf("loading resource from specs: %w", err)
+		return nil, fmt.Errorf("loading resource from old specs: %w", err)
+	}
+	baselineModule, err := GenerateInMemory(resourceType,
+		baselineResult,
+		WithLocalName(opts.LocalName),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("generating baseline module: %w", err)
+	}
+	baselineVarTypes := ExtractVariableTypes(baselineModule.Variables)
+	var baselineLocalAssignments map[string]hclwrite.Tokens
+	if baselineModule.Locals != nil {
+		baselineLocalAssignments = ExtractLocalAssignments(baselineModule.Locals)
 	}
 
-	// Step 3: Generate new module from new spec (in memory)
+	// Step 3: Generate new module from new spec.
+	newResult, err := LoadResource(ctx, opts.NewSpecs, resourceType)
+	if err != nil {
+		return nil, fmt.Errorf("loading resource from new specs: %w", err)
+	}
 	newModule, err := GenerateInMemory(resourceType,
-		baselineResult,
+		newResult,
 		WithLocalName(opts.LocalName),
 	)
 	if err != nil {
@@ -117,24 +138,23 @@ func Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
 		NewVersion: newVersion,
 	}
 
-	// For baseline comparison, we generate from the new spec (since we don't have
-	// the old spec pinned). This means we compare on-disk types against the new
-	// generated types. Items that match the new spec are unchanged; items that differ
-	// may be user-modified OR changed by the new spec. Without the old spec baseline,
-	// we take the conservative approach: only auto-update items where we can determine
-	// the on-disk content was generated (not user-modified).
-	//
-	// For a proper 3-way comparison, we'd need the old spec. For now, we use a simpler
-	// 2-way approach: compare on-disk against new, and auto-apply all changes.
-	// The user is expected to review the diff.
+	// Step 4: 3-way comparison and apply changes.
+	// Compare on-disk against baseline to detect user modifications, then apply
+	// new spec changes only to unmodified items.
+	varComparison := CompareVariables(onDiskVarTypes, baselineVarTypes, newVarTypes)
+	localComparison := CompareLocals(onDiskLocalAssignments, baselineLocalAssignments, newLocalAssignments)
 
 	if !opts.DryRun {
 		// Update variables.tf
-		result.Variables = applyVariableChanges(varsFile, newModule.Variables, onDiskVarTypes, newVarTypes)
+		result.Variables = applyVariableChanges(varsFile, newModule.Variables, newVarTypes, varComparison)
 
-		// Update locals.tf
-		if localsFile != nil && newModule.Locals != nil {
-			result.Locals = applyLocalChanges(localsFile, newModule.Locals, onDiskLocalAssignments, newLocalAssignments)
+		// Update locals.tf — create the file if it doesn't exist but the new spec needs one.
+		if newModule.Locals != nil {
+			if localsFile == nil {
+				localsFile = hclwrite.NewEmptyFile()
+				localsFile.Body().AppendNewBlock("locals", nil)
+			}
+			result.Locals = applyLocalChanges(localsFile, newModule.Locals, newLocalAssignments, localComparison)
 		}
 
 		// Update main.tf: type attribute and response_export_values
@@ -165,11 +185,9 @@ func Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
 			result.OutputsRegenerated = true
 		}
 	} else {
-		// Dry run: compute what would change without writing
-		result.Variables = computeVariableChanges(onDiskVarTypes, newVarTypes)
-		if onDiskLocalAssignments != nil {
-			result.Locals = computeLocalChanges(onDiskLocalAssignments, newLocalAssignments)
-		}
+		// Dry run: compute what would change using the 3-way comparison.
+		result.Variables = summarizeComparison(varComparison)
+		result.Locals = summarizeComparison(localComparison)
 		result.MainUpdated = oldVersion != newVersion
 		result.OutputsRegenerated = true
 	}
@@ -177,109 +195,110 @@ func Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
 	return result, nil
 }
 
-// applyVariableChanges modifies the on-disk variables file based on the new generated variables.
-func applyVariableChanges(diskFile, newFile *hclwrite.File, diskTypes, newTypes map[string]hclwrite.Tokens) UpdateSummary {
+// applyVariableChanges modifies the on-disk variables file based on the 3-way comparison results.
+func applyVariableChanges(diskFile, newFile *hclwrite.File, newTypes map[string]hclwrite.Tokens, comparison map[string]CompareResult) UpdateSummary {
 	var summary UpdateSummary
 
-	// Update existing variables and detect removals
-	for name, diskTokens := range diskTypes {
-		newTokens, inNew := newTypes[name]
-		if !inNew {
-			// Variable removed in new spec — remove it
-			if err := RemoveVariableBlock(diskFile, name); err == nil {
-				summary.Removed = append(summary.Removed, name)
+	for name, cmp := range comparison {
+		switch cmp {
+		case CompareIdentical:
+			// On-disk matches baseline; update to new spec type.
+			newTokens, ok := newTypes[name]
+			if !ok {
+				continue
 			}
-			continue
-		}
-		if TokensEqual(diskTokens, newTokens) {
-			summary.Unchanged = append(summary.Unchanged, name)
-		} else {
-			// Type changed — update it
-			if err := UpdateVariableType(diskFile, name, newTokens); err == nil {
-				summary.AutoUpdated = append(summary.AutoUpdated, name)
+			if err := UpdateVariableType(diskFile, name, newTokens); err != nil {
+				summary.NeedsReview = append(summary.NeedsReview, name+" (update failed: "+err.Error()+")")
+				continue
 			}
-		}
-	}
-
-	// Add new variables
-	for name := range newTypes {
-		if _, exists := diskTypes[name]; exists {
-			continue
-		}
-		if err := AddVariableBlock(diskFile, newFile, name); err == nil {
-			summary.Added = append(summary.Added, name)
-		}
-	}
-
-	return summary
-}
-
-// applyLocalChanges modifies the on-disk locals file based on the new generated locals.
-func applyLocalChanges(diskFile, newFile *hclwrite.File, diskLocals, newLocals map[string]hclwrite.Tokens) UpdateSummary {
-	var summary UpdateSummary
-
-	// Update existing locals and detect removals
-	for name, diskTokens := range diskLocals {
-		newTokens, inNew := newLocals[name]
-		if !inNew {
-			if err := RemoveLocalAttribute(diskFile, name); err == nil {
-				summary.Removed = append(summary.Removed, name)
-			}
-			continue
-		}
-		if TokensEqual(diskTokens, newTokens) {
-			summary.Unchanged = append(summary.Unchanged, name)
-		} else {
-			if err := UpdateLocalAttribute(diskFile, name, newTokens); err == nil {
-				summary.AutoUpdated = append(summary.AutoUpdated, name)
-			}
-		}
-	}
-
-	// Add new locals
-	newLocalAssignments := ExtractLocalAssignments(newFile)
-	for name, tokens := range newLocalAssignments {
-		if _, exists := diskLocals[name]; exists {
-			continue
-		}
-		if err := AddLocalAttribute(diskFile, name, tokens); err == nil {
-			summary.Added = append(summary.Added, name)
-		}
-	}
-
-	return summary
-}
-
-// computeVariableChanges computes what would change without modifying files (dry run).
-func computeVariableChanges(diskTypes, newTypes map[string]hclwrite.Tokens) UpdateSummary {
-	var summary UpdateSummary
-
-	for name, diskTokens := range diskTypes {
-		newTokens, inNew := newTypes[name]
-		if !inNew {
-			summary.Removed = append(summary.Removed, name)
-			continue
-		}
-		if TokensEqual(diskTokens, newTokens) {
-			summary.Unchanged = append(summary.Unchanged, name)
-		} else {
 			summary.AutoUpdated = append(summary.AutoUpdated, name)
-		}
-	}
 
-	for name := range newTypes {
-		if _, exists := diskTypes[name]; exists {
-			continue
+		case CompareModified:
+			// User has customized this variable — flag for manual review.
+			summary.NeedsReview = append(summary.NeedsReview, name)
+
+		case CompareNew:
+			// New variable in the new spec — add it.
+			if err := AddVariableBlock(diskFile, newFile, name); err != nil {
+				summary.NeedsReview = append(summary.NeedsReview, name+" (add failed: "+err.Error()+")")
+				continue
+			}
+			summary.Added = append(summary.Added, name)
+
+		case CompareRemoved:
+			// Variable removed in the new spec — remove it.
+			if err := RemoveVariableBlock(diskFile, name); err != nil {
+				summary.NeedsReview = append(summary.NeedsReview, name+" (remove failed: "+err.Error()+")")
+				continue
+			}
+			summary.Removed = append(summary.Removed, name)
 		}
-		summary.Added = append(summary.Added, name)
 	}
 
 	return summary
 }
 
-// computeLocalChanges computes what local changes would be made (dry run).
-func computeLocalChanges(diskLocals, newLocals map[string]hclwrite.Tokens) UpdateSummary {
-	return computeVariableChanges(diskLocals, newLocals)
+// applyLocalChanges modifies the on-disk locals file based on the 3-way comparison results.
+func applyLocalChanges(diskFile, newFile *hclwrite.File, newLocals map[string]hclwrite.Tokens, comparison map[string]CompareResult) UpdateSummary {
+	var summary UpdateSummary
+
+	newLocalAssignments := ExtractLocalAssignments(newFile)
+
+	for name, cmp := range comparison {
+		switch cmp {
+		case CompareIdentical:
+			newTokens, ok := newLocals[name]
+			if !ok {
+				continue
+			}
+			if err := UpdateLocalAttribute(diskFile, name, newTokens); err != nil {
+				summary.NeedsReview = append(summary.NeedsReview, name+" (update failed: "+err.Error()+")")
+				continue
+			}
+			summary.AutoUpdated = append(summary.AutoUpdated, name)
+
+		case CompareModified:
+			summary.NeedsReview = append(summary.NeedsReview, name)
+
+		case CompareNew:
+			tokens, ok := newLocalAssignments[name]
+			if !ok {
+				continue
+			}
+			if err := AddLocalAttribute(diskFile, name, tokens); err != nil {
+				summary.NeedsReview = append(summary.NeedsReview, name+" (add failed: "+err.Error()+")")
+				continue
+			}
+			summary.Added = append(summary.Added, name)
+
+		case CompareRemoved:
+			if err := RemoveLocalAttribute(diskFile, name); err != nil {
+				summary.NeedsReview = append(summary.NeedsReview, name+" (remove failed: "+err.Error()+")")
+				continue
+			}
+			summary.Removed = append(summary.Removed, name)
+		}
+	}
+
+	return summary
+}
+
+// summarizeComparison converts a comparison map to an UpdateSummary for dry-run mode.
+func summarizeComparison(comparison map[string]CompareResult) UpdateSummary {
+	var summary UpdateSummary
+	for name, cmp := range comparison {
+		switch cmp {
+		case CompareIdentical:
+			summary.AutoUpdated = append(summary.AutoUpdated, name)
+		case CompareModified:
+			summary.NeedsReview = append(summary.NeedsReview, name)
+		case CompareNew:
+			summary.Added = append(summary.Added, name)
+		case CompareRemoved:
+			summary.Removed = append(summary.Removed, name)
+		}
+	}
+	return summary
 }
 
 // writeHCLFile writes a parsed HCL file back to disk.

--- a/terraform/update.go
+++ b/terraform/update.go
@@ -1,0 +1,288 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// UpdateResult holds the outcome of an update operation.
+type UpdateResult struct {
+	OldVersion         string
+	NewVersion         string
+	Variables          UpdateSummary
+	Locals             UpdateSummary
+	MainUpdated        bool
+	OutputsRegenerated bool
+}
+
+// UpdateSummary classifies the changes made to a set of named items (variables or locals).
+type UpdateSummary struct {
+	AutoUpdated []string // names of items auto-updated
+	Added       []string // names of new items added
+	Removed     []string // names of items removed
+	NeedsReview []string // names of user-modified items requiring manual attention
+	Unchanged   []string // names of items identical between old and new spec
+}
+
+// UpdateOptions configures how the update is performed.
+type UpdateOptions struct {
+	// ModuleDir is the directory containing the existing module.
+	ModuleDir string
+	// NewSpecs is a list of paths or URLs to the new OpenAPI spec files.
+	NewSpecs []string
+	// ResourceType overrides the resource type (if empty, inferred from main.tf).
+	ResourceType string
+	// LocalName overrides the local variable name (default: "resource_body").
+	LocalName string
+	// DryRun, when true, computes changes without writing to disk.
+	DryRun bool
+}
+
+// Update upgrades an existing Terraform module to a new API version while preserving
+// user customizations.
+func Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
+	if opts.ModuleDir == "" {
+		opts.ModuleDir = "."
+	}
+	if opts.LocalName == "" {
+		opts.LocalName = "resource_body"
+	}
+
+	// Step 1: Read current module state
+	mainFile, err := ParseModuleFile(opts.ModuleDir, "main.tf")
+	if err != nil {
+		return nil, fmt.Errorf("reading main.tf: %w", err)
+	}
+	resourceType, oldVersion, err := ExtractResourceTypeAndVersion(mainFile)
+	if err != nil {
+		return nil, fmt.Errorf("extracting resource type and version: %w", err)
+	}
+	if opts.ResourceType != "" {
+		resourceType = opts.ResourceType
+	}
+
+	varsFile, err := ParseModuleFile(opts.ModuleDir, "variables.tf")
+	if err != nil {
+		return nil, fmt.Errorf("reading variables.tf: %w", err)
+	}
+	onDiskVarTypes := ExtractVariableTypes(varsFile)
+
+	var onDiskLocalAssignments map[string]hclwrite.Tokens
+	localsPath := filepath.Join(opts.ModuleDir, "locals.tf")
+	var localsFile *hclwrite.File
+	if _, statErr := os.Stat(localsPath); statErr == nil {
+		localsFile, err = ParseHCLFile(localsPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading locals.tf: %w", err)
+		}
+		onDiskLocalAssignments = ExtractLocalAssignments(localsFile)
+	}
+
+	// Step 2: Generate baseline from current spec (in memory)
+	baselineResult, err := LoadResource(ctx, opts.NewSpecs, resourceType)
+	if err != nil {
+		// If we can't load from the new specs with the old version, we might need
+		// the current spec. For now, generate baseline from what we have on disk.
+		// The baseline is used for dirty detection. If we can't produce one, we treat
+		// everything as user-modified (conservative).
+		return nil, fmt.Errorf("loading resource from specs: %w", err)
+	}
+
+	// Step 3: Generate new module from new spec (in memory)
+	newModule, err := GenerateInMemory(resourceType,
+		baselineResult,
+		WithLocalName(opts.LocalName),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("generating new module: %w", err)
+	}
+
+	newVarTypes := ExtractVariableTypes(newModule.Variables)
+	_, newVersion, err := ExtractResourceTypeAndVersion(newModule.Main)
+	if err != nil {
+		return nil, fmt.Errorf("extracting new version: %w", err)
+	}
+
+	var newLocalAssignments map[string]hclwrite.Tokens
+	if newModule.Locals != nil {
+		newLocalAssignments = ExtractLocalAssignments(newModule.Locals)
+	}
+
+	result := &UpdateResult{
+		OldVersion: oldVersion,
+		NewVersion: newVersion,
+	}
+
+	// For baseline comparison, we generate from the new spec (since we don't have
+	// the old spec pinned). This means we compare on-disk types against the new
+	// generated types. Items that match the new spec are unchanged; items that differ
+	// may be user-modified OR changed by the new spec. Without the old spec baseline,
+	// we take the conservative approach: only auto-update items where we can determine
+	// the on-disk content was generated (not user-modified).
+	//
+	// For a proper 3-way comparison, we'd need the old spec. For now, we use a simpler
+	// 2-way approach: compare on-disk against new, and auto-apply all changes.
+	// The user is expected to review the diff.
+
+	if !opts.DryRun {
+		// Update variables.tf
+		result.Variables = applyVariableChanges(varsFile, newModule.Variables, onDiskVarTypes, newVarTypes)
+
+		// Update locals.tf
+		if localsFile != nil && newModule.Locals != nil {
+			result.Locals = applyLocalChanges(localsFile, newModule.Locals, onDiskLocalAssignments, newLocalAssignments)
+		}
+
+		// Update main.tf: type attribute and response_export_values
+		newTypeString := resourceType + "@" + newVersion
+		if err := UpdateResourceTypeAttribute(mainFile, newTypeString); err != nil {
+			return nil, fmt.Errorf("updating type attribute: %w", err)
+		}
+		result.MainUpdated = true
+
+		// Write updated files
+		if err := writeHCLFile(filepath.Join(opts.ModuleDir, "variables.tf"), varsFile); err != nil {
+			return nil, fmt.Errorf("writing variables.tf: %w", err)
+		}
+		if err := writeHCLFile(filepath.Join(opts.ModuleDir, "main.tf"), mainFile); err != nil {
+			return nil, fmt.Errorf("writing main.tf: %w", err)
+		}
+		if localsFile != nil {
+			if err := writeHCLFile(filepath.Join(opts.ModuleDir, "locals.tf"), localsFile); err != nil {
+				return nil, fmt.Errorf("writing locals.tf: %w", err)
+			}
+		}
+
+		// Regenerate outputs.tf from new spec
+		if newModule.Outputs != nil {
+			if err := writeHCLFile(filepath.Join(opts.ModuleDir, "outputs.tf"), newModule.Outputs); err != nil {
+				return nil, fmt.Errorf("writing outputs.tf: %w", err)
+			}
+			result.OutputsRegenerated = true
+		}
+	} else {
+		// Dry run: compute what would change without writing
+		result.Variables = computeVariableChanges(onDiskVarTypes, newVarTypes)
+		if onDiskLocalAssignments != nil {
+			result.Locals = computeLocalChanges(onDiskLocalAssignments, newLocalAssignments)
+		}
+		result.MainUpdated = oldVersion != newVersion
+		result.OutputsRegenerated = true
+	}
+
+	return result, nil
+}
+
+// applyVariableChanges modifies the on-disk variables file based on the new generated variables.
+func applyVariableChanges(diskFile, newFile *hclwrite.File, diskTypes, newTypes map[string]hclwrite.Tokens) UpdateSummary {
+	var summary UpdateSummary
+
+	// Update existing variables and detect removals
+	for name, diskTokens := range diskTypes {
+		newTokens, inNew := newTypes[name]
+		if !inNew {
+			// Variable removed in new spec — remove it
+			if err := RemoveVariableBlock(diskFile, name); err == nil {
+				summary.Removed = append(summary.Removed, name)
+			}
+			continue
+		}
+		if TokensEqual(diskTokens, newTokens) {
+			summary.Unchanged = append(summary.Unchanged, name)
+		} else {
+			// Type changed — update it
+			if err := UpdateVariableType(diskFile, name, newTokens); err == nil {
+				summary.AutoUpdated = append(summary.AutoUpdated, name)
+			}
+		}
+	}
+
+	// Add new variables
+	for name := range newTypes {
+		if _, exists := diskTypes[name]; exists {
+			continue
+		}
+		if err := AddVariableBlock(diskFile, newFile, name); err == nil {
+			summary.Added = append(summary.Added, name)
+		}
+	}
+
+	return summary
+}
+
+// applyLocalChanges modifies the on-disk locals file based on the new generated locals.
+func applyLocalChanges(diskFile, newFile *hclwrite.File, diskLocals, newLocals map[string]hclwrite.Tokens) UpdateSummary {
+	var summary UpdateSummary
+
+	// Update existing locals and detect removals
+	for name, diskTokens := range diskLocals {
+		newTokens, inNew := newLocals[name]
+		if !inNew {
+			if err := RemoveLocalAttribute(diskFile, name); err == nil {
+				summary.Removed = append(summary.Removed, name)
+			}
+			continue
+		}
+		if TokensEqual(diskTokens, newTokens) {
+			summary.Unchanged = append(summary.Unchanged, name)
+		} else {
+			if err := UpdateLocalAttribute(diskFile, name, newTokens); err == nil {
+				summary.AutoUpdated = append(summary.AutoUpdated, name)
+			}
+		}
+	}
+
+	// Add new locals
+	newLocalAssignments := ExtractLocalAssignments(newFile)
+	for name, tokens := range newLocalAssignments {
+		if _, exists := diskLocals[name]; exists {
+			continue
+		}
+		if err := AddLocalAttribute(diskFile, name, tokens); err == nil {
+			summary.Added = append(summary.Added, name)
+		}
+	}
+
+	return summary
+}
+
+// computeVariableChanges computes what would change without modifying files (dry run).
+func computeVariableChanges(diskTypes, newTypes map[string]hclwrite.Tokens) UpdateSummary {
+	var summary UpdateSummary
+
+	for name, diskTokens := range diskTypes {
+		newTokens, inNew := newTypes[name]
+		if !inNew {
+			summary.Removed = append(summary.Removed, name)
+			continue
+		}
+		if TokensEqual(diskTokens, newTokens) {
+			summary.Unchanged = append(summary.Unchanged, name)
+		} else {
+			summary.AutoUpdated = append(summary.AutoUpdated, name)
+		}
+	}
+
+	for name := range newTypes {
+		if _, exists := diskTypes[name]; exists {
+			continue
+		}
+		summary.Added = append(summary.Added, name)
+	}
+
+	return summary
+}
+
+// computeLocalChanges computes what local changes would be made (dry run).
+func computeLocalChanges(diskLocals, newLocals map[string]hclwrite.Tokens) UpdateSummary {
+	return computeVariableChanges(diskLocals, newLocals)
+}
+
+// writeHCLFile writes a parsed HCL file back to disk.
+func writeHCLFile(path string, file *hclwrite.File) error {
+	return os.WriteFile(path, file.Bytes(), 0o644)
+}


### PR DESCRIPTION
## Summary

- Add a new `tfmodmake update` CLI command that upgrades an existing Terraform module to a new Azure API version while preserving user customizations
- Refactor generation pipeline into build/write pairs (`buildX()` / `generateX()`) enabling in-memory output via `GenerateInMemory()`
- Add HCL parsing, comparison, and editing utilities for detecting user modifications and applying surgical updates

## How it works

1. Parses the existing module's `main.tf` to extract the current resource type and API version
2. Resolves both the old (current) and new (latest) OpenAPI specs using pinned version lookup
3. Generates baseline (old spec) and target (new spec) modules in memory
4. Compares on-disk files against the baseline to classify each variable/local as identical, modified, new, or removed
5. Auto-upgrades unmodified items to the new spec; leaves user-customized items untouched with a summary

## Changes

### New files (1,700 lines)
- `cmd/tfmodmake/update.go` — CLI command handler with summary reporting
- `terraform/update.go` — Core update orchestrator
- `terraform/parse_existing.go` — HCL parsing and extraction utilities
- `terraform/compare.go` — Token normalization and comparison
- `terraform/hcl_edit.go` — In-place HCL editing operations
- `terraform/*_test.go` — Tests for parsing, comparison, and editing (3 test files)

### Modified files
- `terraform/generate_*.go` — Split into `buildX()` + `generateX()` pairs
- `terraform/generator.go` — Added `GeneratedModule` struct and `GenerateInMemory()`
- `specs/spec_resolver.go` — Added `PinVersion` field to `ResolveRequest`
- `specs/spec_discovery.go` — Added `discoverPinnedVersionSpecsFromGitHubDir()`
- `cmd/tfmodmake/main.go` — Registered `UpdateCommand()`

## Testing

All tests pass (`go test ./...` — 7 packages, 83+ test functions in terraform package).