### PR TITLE
fix: set depth to 0 (unlimited)

### DIFF
--- a/cmd/tfmodmake/discover.go
+++ b/cmd/tfmodmake/discover.go
@@ -62,7 +62,7 @@ func runDiscoverChildren(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to parse bicep-types index: %w", err)
 	}
 
-	children := schema.DiscoverChildren(idx, parent, 1)
+	children := schema.DiscoverChildren(idx, parent, 0)
 
 	if jsonOutput {
 		data, err := json.MarshalIndent(children, "", "  ")


### PR DESCRIPTION
- Changed the initial depth argument in the call to `schema.DiscoverChildren` from `1` to `0` in `discover.go`, allowing for 'unlimited' discovery of child resources.

This supports resources such as storage accounts.