### PR TITLE
feat: allow gen avm to ignore features that only exist in preview

### DIFF
--- a/bicepdata/loader.go
+++ b/bicepdata/loader.go
@@ -2,6 +2,7 @@ package bicepdata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -9,6 +10,24 @@ import (
 	"github.com/Azure/bicep-types/src/bicep-types-go/index"
 	"github.com/Azure/bicep-types/src/bicep-types-go/types"
 )
+
+// ErrNoStableVersions is returned when a resource type has only preview API versions
+// and --include-preview was not specified.
+type ErrNoStableVersions struct {
+	ResourceType    string
+	PreviewVersions []string
+}
+
+func (e *ErrNoStableVersions) Error() string {
+	return fmt.Sprintf("no stable API versions found for %s (preview versions available: %s); use --include-preview to select one",
+		e.ResourceType, strings.Join(e.PreviewVersions, ", "))
+}
+
+// IsErrNoStableVersions reports whether err (or any error in its chain) is an ErrNoStableVersions.
+func IsErrNoStableVersions(err error) bool {
+	var target *ErrNoStableVersions
+	return errors.As(err, &target)
+}
 
 // LoadedResource contains a resolved resource type and its supporting type array.
 type LoadedResource struct {
@@ -159,8 +178,7 @@ func resolveLatestVersion(idx *index.TypeIndex, resourceType string, includePrev
 	}
 
 	if len(preview) > 0 {
-		return "", fmt.Errorf("no stable API versions found for %s (preview versions available: %s); use --include-preview to select one",
-			resourceType, strings.Join(preview, ", "))
+		return "", &ErrNoStableVersions{ResourceType: resourceType, PreviewVersions: preview}
 	}
 
 	return "", fmt.Errorf("no API versions found for resource type %s", resourceType)

--- a/cmd/tfmodmake/gen.go
+++ b/cmd/tfmodmake/gen.go
@@ -258,6 +258,10 @@ func orchestrateAVMGeneration(ctx context.Context, resourceType, apiVersion stri
 			modulePath := filepath.Join(moduleDir, moduleName)
 
 			if err := generateChildModule(ctx, child.ResourceType, apiVersion, includePreview, modulePath); err != nil {
+				if bicepdata.IsErrNoStableVersions(err) {
+					fmt.Fprintf(os.Stderr, "  [%d/%d] WARNING: skipping %s — only preview API versions available (use --include-preview to include)\n", i+1, len(children), child.ResourceType)
+					continue
+				}
 				return fmt.Errorf("failed to generate child module for %s: %w", child.ResourceType, err)
 			}
 


### PR DESCRIPTION
This pull request introduces improved error handling for cases where only preview API versions are available for a resource type in the `bicepdata` package. The main enhancement is the addition of a custom error type to clearly indicate when no stable API versions exist, and updates to both the loader logic and command-line tool to handle this scenario gracefully.

Error handling improvements:

* Added a new error type `ErrNoStableVersions` in `loader.go` to represent the case when a resource type has only preview API versions, along with a helper function `IsErrNoStableVersions` to check for this error.
* Updated the `resolveLatestVersion` function in `loader.go` to return the new `ErrNoStableVersions` error instead of a generic error when only preview versions are found.
* Modified the AVM generation logic in `gen.go` to detect `ErrNoStableVersions` errors, print a warning, and skip the resource instead of failing the whole process.

Other changes:

* Added the `errors` package import to `loader.go` to support error wrapping and type assertions.